### PR TITLE
Add :event field and remove "action" prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ Composer Renderer
 ### Specs
 
 ```
-Type       props              Action
+Type       props              Event
 ----
 
-box                           action, data
+box                           param
 space      width, height
 divider    kind, color
 text       value
 some       value, kind
-button     text               action, data
-link       text, href         action, data
-icon       name               action, data
+button     text               param
+link       text, href         param
+icon       name               param
 template   name, data
-list       value
-input      value, textarea    action, data
+list       value              param
+input      value, textarea    param
 slot       dom
 inspect    title
 popup      visible

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ data inside list children
 
 `some` instruction kinds:
 
-* `nil` or `"value"`, detect with `nil?`
-* `"list"`, detect with `empty?`
-* `"boolean"`, detect with `#(= "false" %)`
+* `nil` or `:value`, detect with `nil?`
+* `:list`, detect with `empty?`
+* `:boolean`, detect with `#(= "false" %)`
 
 `space` props:
 
@@ -79,7 +79,7 @@ data inside list children
 
 `divider` props:
 
-* `kind`, defaults to horizontal, could be `vertical` or `v`
+* `kind`, defaults to horizontal, could be `:vertical`
 * `color`, defaults to `#eee`
 
 ### Workflow

--- a/calcit.edn
+++ b/calcit.edn
@@ -2358,94 +2358,6 @@
        }
       }
      }
-     "parse-token" {
-      :type :expr, :by "rJG4IHzWf", :at 1549977348493, :id "ZKXm5LjmBP"
-      :data {
-       "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977348493, :text "defn", :id "vs97OeRmSx"}
-       "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977348493, :text "parse-token", :id "-x3q6S7I1I"}
-       "r" {
-        :type :expr, :by "rJG4IHzWf", :at 1549977348493, :id "mh52PKONnG"
-        :data {
-         "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977352954, :text "x", :id "NcGxGQuvB"}
-        }
-       }
-       "v" {
-        :type :expr, :by "rJG4IHzWf", :at 1549977353484, :id "O9CYeJaE-c"
-        :data {
-         "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977360029, :text "cond", :id "O9CYeJaE-cleaf"}
-         "j" {
-          :type :expr, :by "rJG4IHzWf", :at 1549977360787, :id "kuNk_I_Kb"
-          :data {
-           "T" {
-            :type :expr, :by "rJG4IHzWf", :at 1549977361012, :id "6N9sBDrdkd"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977367298, :text "string/starts-with?", :id "ZEFurK7Fu1"}
-             "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977368234, :text "x", :id "KsAZ5JboUl"}
-             "r" {:type :leaf, :by "rJG4IHzWf", :at 1549977373958, :text "\":", :id "PCjG6Nzgn"}
-            }
-           }
-           "j" {
-            :type :expr, :by "rJG4IHzWf", :at 1549977376035, :id "nRH6zINyi"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977377771, :text "keyword", :id "nRH6zINyileaf"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1549977378371, :id "tU2CZ_MIht"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977378790, :text "subs", :id "k6Bsbrk7Lh"}
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977379264, :text "x", :id "jcMcNfpTk5"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1549977379711, :text "1", :id "Yq6QujmlBC"}
-              }
-             }
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "rJG4IHzWf", :at 1549977360787, :id "tpadm1mkKE"
-          :data {
-           "T" {
-            :type :expr, :by "rJG4IHzWf", :at 1549977361012, :id "6N9sBDrdkd"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977367298, :text "string/starts-with?", :id "ZEFurK7Fu1"}
-             "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977368234, :text "x", :id "KsAZ5JboUl"}
-             "r" {:type :leaf, :by "rJG4IHzWf", :at 1549977384160, :text "\"|", :id "PCjG6Nzgn"}
-            }
-           }
-           "j" {
-            :type :expr, :by "rJG4IHzWf", :at 1549977378371, :id "tU2CZ_MIht"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977378790, :text "subs", :id "k6Bsbrk7Lh"}
-             "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977379264, :text "x", :id "jcMcNfpTk5"}
-             "r" {:type :leaf, :by "rJG4IHzWf", :at 1549977379711, :text "1", :id "Yq6QujmlBC"}
-            }
-           }
-          }
-         }
-         "v" {
-          :type :expr, :by "rJG4IHzWf", :at 1549977443724, :id "14RYqAaLH"
-          :data {
-           "D" {:type :leaf, :by "rJG4IHzWf", :at 1549977446029, :text ":else", :id "V8PSrL41J0"}
-           "T" {
-            :type :expr, :by "rJG4IHzWf", :at 1549977389373, :id "pMTGMSXhFt"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977391024, :text "do", :id "pMTGMSXhFtleaf"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1549977392276, :id "oJSlYLsbF-"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977395088, :text "js/console.error", :id "ak2fIrOnKR"}
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977419891, :text "\"Failed to parse token:", :id "Wz7uDA6m-C"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1549977405254, :text "x", :id "pYcCN_pvbA"}
-              }
-             }
-             "r" {:type :leaf, :by "rJG4IHzWf", :at 1549977422612, :text "nil", :id "KyTjQMFFK"}
-            }
-           }
-          }
-         }
-        }
-       }
-      }
-     }
      "read-by-marks" {
       :type :expr, :by "rJG4IHzWf", :at 1549977242550, :id "69TNf1quH-"
       :data {
@@ -2509,8 +2421,9 @@
                  "j" {
                   :type :expr, :by "rJG4IHzWf", :at 1549977279865, :id "bcPxCtDj6E"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1549977294694, :text "parse-token", :id "yi18Fb8T0"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217346489, :text "read-token", :id "yi18Fb8T0"}
                    "j" {:type :leaf, :by "rJG4IHzWf", :at 1549977299917, :text "x", :id "A51OW3PZw"}
+                   "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217348187, :text "scope", :id "VUgnmamx66"}
                   }
                  }
                 }
@@ -2585,56 +2498,74 @@
               }
              }
              "n" {
-              :type :expr, :by "rJG4IHzWf", :at 1551513270588, :id "pmdBoDjfTk"
+              :type :expr, :by "rJG4IHzWf", :at 1552217462849, :id "FkoHZnO8fh"
               :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "read-by-marks", :id "NUn10kHFuf"}
-               "j" {
-                :type :expr, :by "rJG4IHzWf", :at 1551513366438, :id "LclXphgZZz"
+               "D" {:type :leaf, :by "rJG4IHzWf", :at 1552217463574, :text "let", :id "Bw9bvIR1A1"}
+               "L" {
+                :type :expr, :by "rJG4IHzWf", :at 1552217463832, :id "nxawJ1T8lm"
                 :data {
-                 "D" {:type :leaf, :by "rJG4IHzWf", :at 1551513368158, :text "filter", :id "jgfbSdEMf"}
-                 "L" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551513371356, :id "vlTQeS3qFm"
+                 "T" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552217465929, :id "I7MzrRdej"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513372119, :text "fn", :id "zaO9_i1JA"}
+                   "D" {:type :leaf, :by "rJG4IHzWf", :at 1552217471119, :text "chunks", :id "XCkbRk7dfe"}
                    "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551513372834, :id "-Zok4zl8Vd"
+                    :type :expr, :by "rJG4IHzWf", :at 1552217476977, :id "ti2jhyk4hs"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513373068, :text "x", :id "TH5i8Fl9v"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551513374341, :id "4TAVI0DfDd"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513374871, :text "not", :id "4TAVI0DfDdleaf"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217476977, :text "filter", :id "Plbsks-_w_"}
                      "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1551513375238, :id "9U1W3x-g41"
+                      :type :expr, :by "rJG4IHzWf", :at 1552217476977, :id "9xLdWMvE-M"
                       :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513381357, :text "string/blank?", :id "d2JT8KSLpX"}
-                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1551513381618, :text "x", :id "Z1RONj4afX"}
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217476977, :text "fn", :id "rduqJluIR6"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552217476977, :id "Uq_XDf_10W"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217476977, :text "x", :id "D8mxa3H4sO"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552217476977, :id "vfunEFt3bR"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217476977, :text "not", :id "z3EdwJTEkA"}
+                         "j" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552217476977, :id "3ELpsO25Dd"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217476977, :text "string/blank?", :id "N71pTYld3z"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217476977, :text "x", :id "MjuYsxVSSk"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552217482275, :id "_bbxEBAylp"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217482275, :text "string/split", :id "AQ5x3sj6Zm"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552217482275, :id "yedXAjUxNS"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217482275, :text "subs", :id "kUd7Xdsxry"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217482275, :text "x", :id "9ua8_fFuKM"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217482275, :text "1", :id "yA-6piwcvw"}
+                        }
+                       }
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217482275, :text "\" ", :id "ctWscHTHRp"}
                       }
                      }
                     }
                    }
                   }
                  }
-                 "T" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551513270588, :id "3_FYT5ZTVD"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "string/split", :id "fHgvH0mUH7"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551513270588, :id "Gx436yVXCG"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "subs", :id "Ams_jAr6Ni"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "x", :id "WSqwt48e5M"}
-                     "r" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "1", :id "KMWk7hJwSU"}
-                    }
-                   }
-                   "r" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "\" ", :id "qosMU-c1Ef"}
-                  }
-                 }
                 }
                }
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "scope", :id "qnwMAOxS01"}
+               "T" {
+                :type :expr, :by "rJG4IHzWf", :at 1551513270588, :id "pmdBoDjfTk"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "read-by-marks", :id "NUn10kHFuf"}
+                 "f" {:type :leaf, :by "rJG4IHzWf", :at 1552217485452, :text "chunks", :id "SLERdsY-RG"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551513270588, :text "scope", :id "qnwMAOxS01"}
+                }
+               }
               }
              }
             }
@@ -2710,6 +2641,53 @@
                "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "subs", :id "loTviY0R02"}
                "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "x", :id "YjejbbeJ6T"}
                "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "1", :id "ib9wFsaJZz"}
+              }
+             }
+            }
+           }
+           "h" {
+            :type :expr, :by "rJG4IHzWf", :at 1552152900876, :id "42aFSQaBB"
+            :data {
+             "T" {
+              :type :expr, :by "rJG4IHzWf", :at 1552152900876, :id "KzqCos0Ztn"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "string/starts-with?", :id "6tFfJ2bWmm"}
+               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "x", :id "-yByccWr35"}
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552216839487, :text "\"\"", :id "3ngYwua0xY"}
+              }
+             }
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552152900876, :id "dSHXgHIsQq"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "subs", :id "loTviY0R02"}
+               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "x", :id "YjejbbeJ6T"}
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "1", :id "ib9wFsaJZz"}
+              }
+             }
+            }
+           }
+           "i" {
+            :type :expr, :by "rJG4IHzWf", :at 1552217547795, :id "4zxKPcE8M"
+            :data {
+             "T" {
+              :type :expr, :by "rJG4IHzWf", :at 1552217554069, :id "sVErAfVAs"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217599409, :text "re-matches", :id "4zxKPcE8Mleaf"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552217558346, :id "M_NrEJmJc-"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217561833, :text "re-pattern", :id "o0aaJ-mDB9"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217574367, :text "\"[\\d\\.]+", :id "ylPfDZDRrQ"}
+                }
+               }
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217577957, :text "x", :id "kW-xe_-711"}
+              }
+             }
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552217579074, :id "dsbGmGftWc"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217579074, :text "js/parseFloat", :id "6ph2yxokAD"}
+               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217579074, :text "x", :id "GQSl6xJXQL"}
               }
              }
             }
@@ -3439,6 +3417,7 @@
         :type :expr, :by "rJG4IHzWf", :at 1551552991809, :id "-IK6bZyNZw"
         :data {
          "T" {:type :leaf, :by "rJG4IHzWf", :at 1551552994673, :text "markup", :id "_wJydERwF"}
+         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216413287, :text "context", :id "wuTfB0rTg"}
         }
        }
        "r" {
@@ -3473,16 +3452,29 @@
                 :type :expr, :by "rJG4IHzWf", :at 1551552898602, :id "vCnfLkBeP_"
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551552898602, :text "#{}", :id "MubSgxREQT"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551552898602, :text "\"vertical", :id "Qd2ffS7Vnl"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551552898602, :text "\"v", :id "ehFetztTb6"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216369575, :text ":vertical", :id "Qd2ffS7Vnl"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552216378859, :text ":v", :id "ehFetztTb6"}
                 }
                }
                "r" {
-                :type :expr, :by "rJG4IHzWf", :at 1551552898602, :id "0J9Ns_-vz1"
+                :type :expr, :by "rJG4IHzWf", :at 1552216384659, :id "yiXll5f3MP"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551552898602, :text "get", :id "KaetVr_LBX"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551552898602, :text "props", :id "m6IvQXZKJy"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551552898602, :text "\"kind", :id "sy_gVYNmha"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216384659, :text "read-token", :id "InkZhwLxEW"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552216384659, :id "yw2svkgejA"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216384659, :text "get", :id "ujhcUWjSR-"}
+                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216384659, :text "props", :id "m1g1o-sx5d"}
+                   "r" {:type :leaf, :by "rJG4IHzWf", :at 1552216387055, :text "\"kind", :id "YDBQLeYicO"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552216384659, :id "AIpvKxYfpQ"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216384659, :text ":data", :id "GEGPhyd5AG"}
+                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216384659, :text "context", :id "Dn3r0cNFcE"}
+                  }
+                 }
                 }
                }
               }
@@ -3545,7 +3537,7 @@
                     :type :expr, :by "rJG4IHzWf", :at 1551552984036, :id "2JDC50sfH61"
                     :data {
                      "T" {:type :leaf, :by "rJG4IHzWf", :at 1551552984036, :text ":height", :id "LiImaK35WlI"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551552984036, :text "\"100%", :id "ovcsoeC3usf"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216697069, :text "\"auto", :id "ovcsoeC3usf"}
                     }
                    }
                   }
@@ -3572,7 +3564,7 @@
                     :type :expr, :by "rJG4IHzWf", :at 1551552984036, :id "HJcSe50lCQU"
                     :data {
                      "T" {:type :leaf, :by "rJG4IHzWf", :at 1551552984036, :text ":width", :id "hdpM7YQkUlg"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551552984036, :text "\"100%", :id "23H7QJaLoUK"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216694797, :text "\"auto", :id "23H7QJaLoUK"}
                     }
                    }
                   }
@@ -5758,6 +5750,7 @@
             :data {
              "T" {:type :leaf, :by "rJG4IHzWf", :at 1549638781696, :text "render-space", :id "iuMT_FXaZ"}
              "j" {:type :leaf, :by "rJG4IHzWf", :at 1549638743914, :text "markup", :id "xUVwqVWj0"}
+             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217665549, :text "context", :id "944HhgfHVT"}
             }
            }
           }
@@ -5771,6 +5764,7 @@
             :data {
              "T" {:type :leaf, :by "rJG4IHzWf", :at 1551552836032, :text "render-divider", :id "iuMT_FXaZ"}
              "j" {:type :leaf, :by "rJG4IHzWf", :at 1549638743914, :text "markup", :id "xUVwqVWj0"}
+             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552216422241, :text "context", :id "IVLH4AAjXq"}
             }
            }
           }
@@ -6603,12 +6597,25 @@
             :type :expr, :by "rJG4IHzWf", :at 1551115667442, :id "_UvICv-H7S"
             :data {
              "T" {:type :leaf, :by "rJG4IHzWf", :at 1551115668432, :text "kind", :id "_UvICv-H7Sleaf"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1551525887953, :id "LFAcvDauDB"
+             "r" {
+              :type :expr, :by "rJG4IHzWf", :at 1552216345424, :id "wZ2H8wI41J"
               :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1551525887953, :text "get", :id "DK6cBdqZSt"}
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1551525887953, :text "props", :id "qR7rGRSc3R"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1551525887953, :text "\"kind", :id "kHR3vkHLAW"}
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216345424, :text "read-token", :id "xuwJLAjLCH"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552216345424, :id "GOl-At-Foo"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216345424, :text "get", :id "NKiVbuQNFI"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216345424, :text "props", :id "BaWyR3zU4h"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552216347615, :text "\"kind", :id "YSVkv3McWu"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552216345424, :id "4TlD-ipra0"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216345424, :text ":data", :id "JzGigCJdi8"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552216345424, :text "context", :id "KLBfXYVjYN"}
+                }
+               }
               }
              }
             }
@@ -6657,7 +6664,7 @@
                "r" {
                 :type :expr, :by "rJG4IHzWf", :at 1551115706699, :id "aB8293bKNJ"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551115712696, :text "\"list", :id "ejecfNeud"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216351324, :text ":list", :id "ejecfNeud"}
                  "j" {
                   :type :expr, :by "rJG4IHzWf", :at 1551115734857, :id "KGBEiTriWE"
                   :data {
@@ -6670,7 +6677,7 @@
                "s" {
                 :type :expr, :by "rJG4IHzWf", :at 1551115746064, :id "KLNSOCUkqe"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551115749405, :text "\"boolean", :id "68pFvhesq2"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216353177, :text ":boolean", :id "68pFvhesq2"}
                  "j" {
                   :type :expr, :by "rJG4IHzWf", :at 1551115750577, :id "efijJIdo9"
                   :data {
@@ -6684,7 +6691,7 @@
                "sT" {
                 :type :expr, :by "rJG4IHzWf", :at 1551290903943, :id "dEoY8GuKSF"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551290903943, :text "\"string", :id "58VI1vnC9j"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216354511, :text ":string", :id "58VI1vnC9j"}
                  "j" {
                   :type :expr, :by "rJG4IHzWf", :at 1551290903943, :id "zdWKbLpCCo"
                   :data {
@@ -6697,7 +6704,7 @@
                "t" {
                 :type :expr, :by "rJG4IHzWf", :at 1551115706699, :id "VGQWdVYdp"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551115740760, :text "\"value", :id "ejecfNeud"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552216356686, :text ":value", :id "ejecfNeud"}
                  "j" {
                   :type :expr, :by "rJG4IHzWf", :at 1551115734857, :id "KGBEiTriWE"
                   :data {
@@ -6831,6 +6838,7 @@
         :type :expr, :by "rJG4IHzWf", :at 1549641567970, :id "bJsC_5Ng1n"
         :data {
          "T" {:type :leaf, :by "rJG4IHzWf", :at 1549641570946, :text "markup", :id "nfzAH3TiNb"}
+         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217660267, :text "context", :id "jDUQa1PQcB"}
         }
        }
        "v" {
@@ -6853,40 +6861,68 @@
              }
             }
            }
+           "j" {
+            :type :expr, :by "rJG4IHzWf", :at 1552217617536, :id "bZM6ZEsuN"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217634605, :text "width", :id "bZM6ZEsuNleaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552217640310, :id "hVwWVNJ_YZ"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "read-token", :id "0IxD_FH-b-"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552217640310, :id "QioxLWiMEd"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "get", :id "jSmMy80l7Y"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "props", :id "GbLJxay-kD"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "\"width", :id "KQkQ053RUE"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552217640310, :id "uaoflKQCIq"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text ":data", :id "CUn0QAP3V2"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "context", :id "5s30R_Wlcc"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "rJG4IHzWf", :at 1552217617536, :id "Qi16M8xXf"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217645595, :text "height", :id "bZM6ZEsuNleaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552217640310, :id "hVwWVNJ_YZ"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "read-token", :id "0IxD_FH-b-"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552217640310, :id "QioxLWiMEd"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "get", :id "jSmMy80l7Y"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "props", :id "GbLJxay-kD"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552217648072, :text "\"height", :id "KQkQ053RUE"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552217640310, :id "uaoflKQCIq"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text ":data", :id "CUn0QAP3V2"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552217640310, :text "context", :id "5s30R_Wlcc"}
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "n" {
           :type :expr, :by "rJG4IHzWf", :at 1549724374063, :id "CEhWHFHm-"
           :data {
            "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724377675, :text "=<", :id "CEhWHFHm-leaf"}
-           "j" {
-            :type :expr, :by "rJG4IHzWf", :at 1549724527485, :id "h9gY-rfjZ"
-            :data {
-             "D" {:type :leaf, :by "rJG4IHzWf", :at 1549724533338, :text "use-number", :id "oNCbRNO1I"}
-             "T" {
-              :type :expr, :by "rJG4IHzWf", :at 1549724380747, :id "yJfXmI-Hx"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724382794, :text "get", :id "zxz7wd1GIv"}
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1549724384401, :text "props", :id "pBR21tbWm"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1549724386545, :text "\"width", :id "PUqTWBVPmY"}
-              }
-             }
-            }
-           }
-           "r" {
-            :type :expr, :by "rJG4IHzWf", :at 1549724535690, :id "B53GYEOfB"
-            :data {
-             "D" {:type :leaf, :by "rJG4IHzWf", :at 1549724536688, :text "use-number", :id "1dW2ar8pom"}
-             "T" {
-              :type :expr, :by "rJG4IHzWf", :at 1549724387246, :id "-_DIX3vgt8"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724387959, :text "get", :id "-_DIX3vgt8leaf"}
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1549724388811, :text "props", :id "qxOg7-vLFd"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1549724390438, :text "\"height", :id "8fEWTALguj"}
-              }
-             }
-            }
-           }
+           "b" {:type :leaf, :by "rJG4IHzWf", :at 1552217651377, :text "width", :id "zJZ59r10bG"}
+           "f" {:type :leaf, :by "rJG4IHzWf", :at 1552217652160, :text "height", :id "X4c4Ga9Wz"}
           }
          }
         }
@@ -7198,40 +7234,6 @@
           :data {
            "T" {:type :leaf, :by "rJG4IHzWf", :at 1549726750984, :text "\"color", :id "mwEeCTjF3jleaf"}
            "j" {:type :leaf, :by "rJG4IHzWf", :at 1549638890958, :text ":red", :id "q1_B8edokX"}
-          }
-         }
-        }
-       }
-      }
-     }
-     "use-number" {
-      :type :expr, :by "rJG4IHzWf", :at 1549724537314, :id "m4X7FxBWT0"
-      :data {
-       "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724537314, :text "defn", :id "-t36lXCMJV"}
-       "j" {:type :leaf, :by "rJG4IHzWf", :at 1549724537314, :text "use-number", :id "QjMBwZcTwz"}
-       "r" {
-        :type :expr, :by "rJG4IHzWf", :at 1549724537314, :id "JOJz4BXA_c"
-        :data {
-         "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724538633, :text "x", :id "v2sXhuToSk"}
-        }
-       }
-       "v" {
-        :type :expr, :by "rJG4IHzWf", :at 1549724539082, :id "B-DOnmci-L"
-        :data {
-         "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724540299, :text "if", :id "B-DOnmci-Lleaf"}
-         "j" {
-          :type :expr, :by "rJG4IHzWf", :at 1549724543758, :id "b7oscc_nFp"
-          :data {
-           "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724541743, :text "nil?", :id "rllv34pRuG"}
-           "j" {:type :leaf, :by "rJG4IHzWf", :at 1549724544164, :text "x", :id "JTKIzwlwgM"}
-          }
-         }
-         "r" {:type :leaf, :by "rJG4IHzWf", :at 1549724546672, :text "nil", :id "yX-sgNDCH6"}
-         "v" {
-          :type :expr, :by "rJG4IHzWf", :at 1549724547739, :id "slYPSzVcH6"
-          :data {
-           "T" {:type :leaf, :by "rJG4IHzWf", :at 1549724554491, :text "js/parseFloat", :id "bk6FPL0Op"}
-           "j" {:type :leaf, :by "rJG4IHzWf", :at 1549724555083, :text "x", :id "ujHkaBu2n"}
           }
          }
         }

--- a/calcit.edn
+++ b/calcit.edn
@@ -2701,7 +2701,7 @@
               :data {
                "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "string/starts-with?", :id "6tFfJ2bWmm"}
                "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "x", :id "-yByccWr35"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152903754, :text "\"", :id "3ngYwua0xY"}
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552193652903, :text "\"|", :id "3ngYwua0xY"}
               }
              }
              "j" {
@@ -2774,7 +2774,7 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589076996, :text "get", :id "RGW9JK2LFV"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589076996, :text "props", :id "U1BUKdfIE_"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551589079833, :text "\"data", :id "q2ST1rsuXf"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552193402628, :text "\"param", :id "q2ST1rsuXf"}
                 }
                }
                "r" {
@@ -2782,6 +2782,144 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589076996, :text ":data", :id "1lE0e8m2kz"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589076996, :text "context", :id "qd9AZfL3Vz"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "rJG4IHzWf", :at 1552192286515, :id "ZGwwq9gadE"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192289937, :text "event-map", :id "ZGwwq9gadEleaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "EfCzgB_kd1"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "->>", :id "hNbuBwjQIj"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "zlI6T4cJ0r"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text ":event", :id "73wBY1abmd"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "markup", :id "l_RhAT2DDW"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "PXGkIAb941"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "map", :id "HdL4R_tVxn"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "wBPh-H3Cnj"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "fn", :id "Rib5xC5DrC"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "BTd9EEBxmG"
+                    :data {
+                     "T" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "9LH1UJAlI8"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "[]", :id "_AYT9NWgMj"}
+                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "name", :id "exSpUwE0nlU"}
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "action", :id "QWvFOnb2GDS"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "fWkb8gSa6"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "[]", :id "aHK3KofJYs"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "name", :id "weqYbYrskz"}
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "l6nRgDuh5d"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "fn", :id "3REGoJbzWG"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "V0E4otXdhd"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "e", :id "9O4x26F045"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "d!", :id "2zSz809dWA"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "m!", :id "GJOHcQREEy"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "OqNCboiB0X"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "on-action", :id "p1xmV1L2ep"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "d!", :id "HrsVY2Xkqw"}
+                         "n" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192345721, :id "Vmom1KZB5i"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192345721, :text "read-token", :id "JC0FDtwE93"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192345721, :text "action", :id "ZqoAqK_a6O"}
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192345721, :id "QUMyoSO6WD"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192345721, :text ":data", :id "w55DVIO7el"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192345721, :text "context", :id "LOFrnnrGJE"}
+                            }
+                           }
+                          }
+                         }
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "param", :id "uu99De54y4"}
+                         "v" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "v1N_eMQFz5"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "{}", :id "JbkJNSznFD"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "fJZlUkG1ap"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text ":event", :id "yLv7LjrWj71"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "o-G82tgkRPj"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text ":event", :id "_NNrdjQ2Cyg"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "e", :id "jArE3am2o5Y"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "a_ceEBXtDPb"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text ":props", :id "CKGixvp3OPg"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "props", :id "lQ5My3vi14f"}
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "Vo8Oq_UU66w"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text ":data", :id "XuVBwZDa7I3"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "qmjAL-sCvXd"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text ":data", :id "xm903Ax6A-q"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "context", :id "fN-mMbziF_8"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "7fF-9mBU_UX"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "into", :id "UUe8bvjBMlj"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192290516, :id "X86X3u04szf"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192290516, :text "{}", :id "aL2YEBd8OQS"}
+                  }
+                 }
                 }
                }
               }
@@ -2871,100 +3009,7 @@
                 :type :expr, :by "rJG4IHzWf", :at 1552153668881, :id "C37IEMCQR"
                 :data {
                  "D" {:type :leaf, :by "rJG4IHzWf", :at 1552154186066, :text ":on", :id "EWTuoqplxb"}
-                 "L" {
-                  :type :expr, :by "rJG4IHzWf", :at 1552153723235, :id "FYHwlzSdoa"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153724599, :text "->>", :id "s328BfH9i"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552153958858, :id "eAYRosqgN2"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153958858, :text ":event", :id "vm04xZ9K9L"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153958858, :text "markup", :id "ojHtROWlme"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552153726904, :id "U3u0Pu1v_"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153727534, :text "map", :id "_X-srgzS5Z"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552153727924, :id "j8SEYLhbzs"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153729074, :text "fn", :id "AfRLFce74l"}
-                       "j" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552153729402, :id "0Fj5V7n1TX"
-                        :data {
-                         "T" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552153729743, :id "svJzMZw-3"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153730076, :text "[]", :id "7OO8UpGHEL"}
-                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153914577, :text "name", :id "3Cn1tuLDmn"}
-                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552153858661, :text "action", :id "aS7A3iOUOz"}
-                          }
-                         }
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552153748021, :id "kPyW2Ogu_0"
-                        :data {
-                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153749310, :text "[]", :id "kPyW2Ogu_0leaf"}
-                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153916502, :text "name", :id "1FXQOqiP_4"}
-                         "r" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552153767677, :id "d5cMO7KQR"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153768006, :text "fn", :id "o0VQ2wquq"}
-                           "j" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552153768619, :id "HrhvZ3YbI"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153768983, :text "e", :id "F-2ZamT-Vs"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153770217, :text "d!", :id "EHPWS80G-"}
-                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552153773715, :text "m!", :id "bkpyU1Z4Y0"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552153780325, :id "ihyz4WRH9"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153783709, :text "on-action", :id "ihyz4WRH9leaf"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153785244, :text "d!", :id "EFMkKswV1O"}
-                             "n" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552153832211, :id "zWzm4PIKxH"
-                              :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text "read-token", :id "jR9ZkSwXrq"}
-                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text "action", :id "FGNkj2U-HZ"}
-                               "r" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552153832211, :id "tjTGaN87rj"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text ":data", :id "yFLFD9ffjS"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text "context", :id "vfB-dTtI0s"}
-                                }
-                               }
-                              }
-                             }
-                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552153788260, :text "props", :id "5meF7FbQH"}
-                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552153794170, :text "param", :id "q5oF8RxTx"}
-                            }
-                           }
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552153753388, :id "pXYUs-QA7g"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153756352, :text "into", :id "pXYUs-QA7gleaf"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552153756630, :id "daUUzKZln"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153756969, :text "{}", :id "iDi-CXXsCz"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
+                 "b" {:type :leaf, :by "rJG4IHzWf", :at 1552192284935, :text "event-map", :id "OST99E8XT"}
                 }
                }
               }
@@ -3079,6 +3124,144 @@
              }
             }
            }
+           "x" {
+            :type :expr, :by "rJG4IHzWf", :at 1552192297365, :id "A2K76hq812"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192298614, :text "event-map", :id "A2K76hq812leaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "0CJWPWJCID"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "->>", :id "ChJ9V6NmFk"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "es1ErfadqV"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text ":event", :id "nMgdsQSVS2"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "markup", :id "9Dq0EW8beW"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "OAy6u03wbW"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "map", :id "JhQ8DIjQbv"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "dol5cHMUD-"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "fn", :id "DKbu6pj-HJ"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "gqK6yzcBZ0"
+                    :data {
+                     "T" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "7_3XNgIR8G"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "[]", :id "5DeYgq2qKL"}
+                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "name", :id "JHvkAd1af3"}
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "action", :id "RATS_Jnb2vP"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "PSU-MRuAFEY"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "[]", :id "iVlS-0QWO68"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "name", :id "TM5zIMoM9Q4"}
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "gSLJhLQIr7X"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "fn", :id "uNo12Y2U2-S"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "t6ZldPaN1kH"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "e", :id "k7HTlRZOd1e"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "d!", :id "_OI4fe3DDwp"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "m!", :id "aA2OLC1OvlG"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "fG7dHOs4l5h"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "on-action", :id "tcvE5MDa9pW"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "d!", :id "gc4qIqaiP81"}
+                         "l" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192338979, :id "0YU28JYTxp"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192338979, :text "read-token", :id "MeCIuvUwR6"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192338979, :text "action", :id "t5rI0UR66C"}
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192338979, :id "DvmrWABRzW"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192338979, :text ":data", :id "Zq019iXN4Y"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192338979, :text "context", :id "K1L3k2npxU"}
+                            }
+                           }
+                          }
+                         }
+                         "n" {:type :leaf, :by "rJG4IHzWf", :at 1552192323232, :text "param", :id "5v_J-2__8s"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192324125, :id "OFs9XMl0gG"
+                          :data {
+                           "D" {:type :leaf, :by "rJG4IHzWf", :at 1552192324708, :text "{}", :id "Uq2JIoPy6A"}
+                           "H" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192358291, :id "R-cOuuRCHw"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192359228, :text ":event", :id "R-cOuuRCHwleaf"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192360693, :id "at6AwJzU6"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192361544, :text ":event", :id "3CGf9vxJxe"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192361812, :text "e", :id "7Y1DEueciQ"}
+                              }
+                             }
+                            }
+                           }
+                           "L" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192325502, :id "KGzhgLySez"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192327523, :text ":props", :id "xYRcKs0Gd_"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192357593, :text "props", :id "ELfL868k0"}
+                            }
+                           }
+                           "f" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192400566, :id "SiBlhLHOh"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192402212, :text ":data", :id "SiBlhLHOhleaf"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192403956, :id "w5jmXoY0Oy"
+                              :data {
+                               "D" {:type :leaf, :by "rJG4IHzWf", :at 1552192405868, :text ":data", :id "PfXMK2vGnI"}
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192403283, :text "context", :id "7hX0Xf-19D"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "bzWExiBUJp0"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "into", :id "eUnkpFwrYf6"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192305325, :id "whyy0C4BNH_"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192305325, :text "{}", :id "WLqhi2yQiLL"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "T" {
@@ -3164,100 +3347,7 @@
                 :type :expr, :by "rJG4IHzWf", :at 1552153902966, :id "9PD5t3_bjc"
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154178814, :text ":on", :id "O7CbXKI9TJ"}
-                 "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "fGQN_mTxMD"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "->>", :id "rZpXOSpEip"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "8u7pQpB6od"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text ":event", :id "F5sGNDnXc_"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "markup", :id "Cl1QIjzXuX"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "Y-ma4d4Fhm"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "map", :id "KFUOm6egQt"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "HNiWmDqTr_"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "fn", :id "XigbDIKe5O"}
-                       "j" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "J8tgJf-f_w"
-                        :data {
-                         "T" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "3RE3yXg-0U"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "[]", :id "G_4jfB7bAh"}
-                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "name", :id "pavhgeW9bn"}
-                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "action", :id "072Gv-cF5i"}
-                          }
-                         }
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "3OUtcgCPXOV"
-                        :data {
-                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "[]", :id "bISe2EudqXZ"}
-                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "name", :id "9_ag_4cZEo4"}
-                         "r" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "rQUHt497SKD"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "fn", :id "9zhDFhodK_5"}
-                           "j" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "8BRpWZORyPl"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "e", :id "RkJtoBFs_8b"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "d!", :id "42LDY7yip0q"}
-                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "m!", :id "JxIQF_8B_uM"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "4qqDKkI5oi6"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "on-action", :id "7M7Fovxcvpz"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "d!", :id "7GkvNsyarsH"}
-                             "r" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "GK7i3SK8fuC"
-                              :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "read-token", :id "kSj8syto6DQ"}
-                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "action", :id "uhesVK2LZDD"}
-                               "r" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "hHubAFit0GT"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text ":data", :id "xx_50TIpq_l"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "context", :id "tJ4nNFyiYuY"}
-                                }
-                               }
-                              }
-                             }
-                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "props", :id "UX7TJZRjU58"}
-                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "param", :id "2hpF4CwIrGq"}
-                            }
-                           }
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "ZbPzgin_I8O"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "into", :id "8guzPE56GYS"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "zxDPFfRftWR"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "{}", :id "dBXsE371fbl"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192303469, :text "event-map", :id "PvQ4DTmg0"}
                 }
                }
               }
@@ -3606,6 +3696,144 @@
              }
             }
            }
+           "x" {
+            :type :expr, :by "rJG4IHzWf", :at 1552192679986, :id "In9pSlwsAh"
+            :data {
+             "D" {:type :leaf, :by "rJG4IHzWf", :at 1552192682446, :text "event-map", :id "MYIWbBJ1ET"}
+             "T" {
+              :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "fje-U1J23e"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "->>", :id "PNZcGrve67"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "vuojtrv4Hs"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text ":event", :id "NyVc1o8qzp"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "markup", :id "m2Bnyzfdo9"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "1aoonruuh-"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "map", :id "tfPJhwWZUm"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "Q0oYZbJLxX"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "fn", :id "Nsx1j7AYuZ"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "oCvu6MKwkU"
+                    :data {
+                     "T" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "wVgi2yAsbD"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "[]", :id "zKj8zBrX2k"}
+                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "name", :id "IDJwGK6VXZ"}
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "action", :id "ERsZYDi50w"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "HOrLh3PyMv"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "[]", :id "JM1e2NHRvt-"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "name", :id "q3WmfpNgoIi"}
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "n-L9H7hmoCL"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "fn", :id "3lRarIX3G2c"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "9hXOxf-wBbD"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "e", :id "D408oH8WZr2"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "d!", :id "c8F7xqs3nQB"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "m!", :id "dpCyTZXlt8x"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "x3BlPRxDPFA"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "on-action", :id "aM0q__stw8_"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "d!", :id "LvptAjRpU9n"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "cgkGLNj4BLo"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "read-token", :id "TwsL0lFG1Sb"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "action", :id "3uhmyyAs9oX"}
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "mlz58ZQrMMT"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text ":data", :id "M4276SyrCCr"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "context", :id "Y90FgvQOoVR"}
+                            }
+                           }
+                          }
+                         }
+                         "x" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "param", :id "ez6IaFGrKaF"}
+                         "y" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192562936, :id "l4kEevQE9Y"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192563318, :text "{}", :id "8ipB8TU4WW"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192563571, :id "TeYvwT6-C"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192565794, :text ":event", :id "BSZYSktl83"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192566017, :id "Bvjla3j4S5"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192566896, :text ":event", :id "ri7yMQnvXS"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192567111, :text "e", :id "_OpWk2HDrU"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192567835, :id "3rwEg953qW"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192571114, :text ":props", :id "3rwEg953qWleaf"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192575538, :text "props", :id "vz5443JAfP"}
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192576114, :id "h4mKHGXLiy"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192577497, :text ":data", :id "h4mKHGXLiyleaf"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192577730, :id "-HyIPxaoOD"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192579083, :text ":data", :id "RXPcq29AS"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192580420, :text "context", :id "bIdpCvSMU_"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "d_N_1lzrkkj"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "into", :id "y__bSloAFB2"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192557848, :id "QCCa0PIKuV0"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192557848, :text "{}", :id "WuMvnS4sS0N"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "T" {
@@ -3690,100 +3918,7 @@
                 :type :expr, :by "rJG4IHzWf", :at 1552154934541, :id "2wY_gcZaO"
                 :data {
                  "D" {:type :leaf, :by "rJG4IHzWf", :at 1552154936749, :text ":on", :id "NxWOcmQjCP"}
-                 "T" {
-                  :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "OMfHVigJrT"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "->>", :id "OnfOV7b-ov"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "vFTLY5Lted"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text ":event", :id "coS3MPvxiT"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "markup", :id "xVUUaRnDVF"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "0yAcNhfIUX"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "map", :id "N3yo6NDosH"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "aPSlekMkQE"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "fn", :id "MCWiiBz_mu"}
-                       "j" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "9pskgHax0-"
-                        :data {
-                         "T" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "0nCiYf-xn4"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "[]", :id "xDH7lHzpYo"}
-                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "name", :id "6q-uj6jMu6"}
-                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "action", :id "MJZDV30oxR"}
-                          }
-                         }
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "oArHGX5WbI"
-                        :data {
-                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "[]", :id "tJ17Lhdxag2"}
-                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "name", :id "0nr896qDXvL"}
-                         "r" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "G8QPRABU35Y"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "fn", :id "vNeif51sSBr"}
-                           "j" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "H5EY6K7rZVi"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "e", :id "M8vzGLgCG5q"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "d!", :id "nYpy09klkQx"}
-                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "m!", :id "xhUUKRxT0LH"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "H6SLv2N0z8l"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "on-action", :id "JBGpSJ1S0Pq"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "d!", :id "CynfiiFzM2t"}
-                             "r" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "SVyvqXwSSr5"
-                              :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "read-token", :id "cKpy57QePqk"}
-                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "action", :id "yBQkteIfQRP"}
-                               "r" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "V3ZoQQmkJJJ"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text ":data", :id "TNkSNtoBZQV"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "context", :id "l8EMQ36UQud"}
-                                }
-                               }
-                              }
-                             }
-                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "props", :id "ob3pZn3jRSk"}
-                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "param", :id "kl33xao4uvp"}
-                            }
-                           }
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "o-FjajSPKVg"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "into", :id "8YEgHtSAl6d"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "VsFSw-kTAf7"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "{}", :id "I7pJWiV4MQJ"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
+                 "b" {:type :leaf, :by "rJG4IHzWf", :at 1552192556095, :text "event-map", :id "8ARw0Dz7f"}
                 }
                }
               }
@@ -3950,6 +4085,144 @@
              }
             }
            }
+           "yj" {
+            :type :expr, :by "rJG4IHzWf", :at 1552192414406, :id "13jReknW_9"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192418085, :text "event-map", :id "13jReknW_9leaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "I0CQOK0Gio"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "->>", :id "kjBV4owKH_"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "79ghgrw_T0"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text ":event", :id "CV1TynYhfX"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "markup", :id "4JY_cHTGhm"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "-E12F8lB2K"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "map", :id "HenSJeXTuz"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "uSeeUYAgZV"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "fn", :id "zQhV1-AzkF"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "BcXOe2hs9B"
+                    :data {
+                     "T" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "Ia5-0CoxLE"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "[]", :id "puEt9rAEps"}
+                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "name", :id "rvzLbIN9mw"}
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "action", :id "3K4A8qhe-R"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "PKnPWw1o5Wr"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "[]", :id "mNZxOaooYJj"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "name", :id "0-ql05gRf4F"}
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "wQmtXwIKSK3"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "fn", :id "vCQkApNZBUB"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "bF_2w5F9nkG"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "e", :id "oUDENAVoRl2"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "d!", :id "vobyyEGMdPj"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "m!", :id "hdGLp3qEEFH"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "x_saSGmaQGd"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "on-action", :id "wF_c_xrDibL"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "d!", :id "dga1JLSrb9E"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "kKJq_Szr7-B"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "read-token", :id "LE6_qqtH9ZK"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "action", :id "icPx1JG7HiD"}
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "tiOBBhOLW5I"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text ":data", :id "Mk8D_wFcXpK"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "context", :id "F-UOmwDcFu1"}
+                            }
+                           }
+                          }
+                         }
+                         "x" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "param", :id "VjAwFEc_zfV"}
+                         "y" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192429130, :id "3Xp_bKm-kS"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192429540, :text "{}", :id "r4CiWDcRLq"}
+                           "b" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192439652, :id "rLvYDVfV1"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192440496, :text ":event", :id "4ZbATW-eEa"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192441120, :id "5FqkHVYtYt"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192441841, :text ":event", :id "wbBSAhvVG"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192442072, :text "e", :id "vsTQKyGQcs"}
+                              }
+                             }
+                            }
+                           }
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192429777, :id "bcTbhANhR2"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192430476, :text ":props", :id "YfAwq96fh9"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192431935, :text "props", :id "0D-wGKHlr"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192432680, :id "5fKM3xJ20"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192433338, :text ":data", :id "5fKM3xJ20leaf"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192434270, :id "YvF8Gm-kq"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192435484, :text ":data", :id "K1u_Tj9F93"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192436641, :text "context", :id "_2n8d-h37"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "f2NZ_oltkAK"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "into", :id "ErzGPmqqnRu"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192424343, :id "9LBmaLNJA1s"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192424343, :text "{}", :id "lalH1reBDX8"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "n" {
@@ -4047,100 +4320,7 @@
                 :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "vdtg0vjNF2"
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text ":on", :id "6VsUgzVrcZ"}
-                 "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "7p63Ecrtjh"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "->>", :id "gHlmESiIT3"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "xRb84fQnHf"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text ":event", :id "LJFQD8AswK"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "markup", :id "mA6omqXXZ6"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "A9RGAPcFWU"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "map", :id "zXtFatLRDl"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "P7Pp-fcMR6"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "fn", :id "ydkqodSZJs"}
-                       "j" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "wmlnrLclyI"
-                        :data {
-                         "T" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "P8p9-H1bRx"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "[]", :id "Ki2oUW-p5K"}
-                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "name", :id "IReN6vn6ddJ"}
-                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "action", :id "zqduZ97ikIo"}
-                          }
-                         }
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "Z8RX9fE614w"
-                        :data {
-                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "[]", :id "CozBRUeGFLo"}
-                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "name", :id "dII_S-eldP-"}
-                         "r" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "4aW_Qxs6aG5"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "fn", :id "u83uC0LDV0d"}
-                           "j" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "40Uz8p2Craf"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "e", :id "FjIV8XZ1Yln"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "d!", :id "8xZ69mBMEWZ"}
-                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "m!", :id "2Gg7nTEjnAi"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "4jbuctq6IY5"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "on-action", :id "sTBxfc8X25t"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "d!", :id "n5SJFw1OtWm"}
-                             "r" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "vOLSP_rEfkN"
-                              :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "read-token", :id "7bDI-lwkGYw"}
-                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "action", :id "Zs867TGOxCX"}
-                               "r" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "A8xOVDxBOgg"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text ":data", :id "uCUrN8MsN9F"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "context", :id "8QNOT5tMx-V"}
-                                }
-                               }
-                              }
-                             }
-                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "props", :id "SniZptUv9o-"}
-                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "param", :id "q3ecTWqdpnz"}
-                            }
-                           }
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "LROUdYRGBzP"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "into", :id "8aL9mOWn6tO"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "j2RrmpiZJ2T"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "{}", :id "g_VzCnCphkh"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192422624, :text "event-map", :id "QchJpHJcv"}
                 }
                }
               }
@@ -4360,53 +4540,72 @@
                          "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "on-action", :id "zkJXYeoZ4V6"}
                          "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "d!", :id "zvwJvafywIe"}
                          "r" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "4Xp2bRI7UN2"
+                          :type :expr, :by "rJG4IHzWf", :at 1552192520101, :id "ctXoAH7bye"
                           :data {
                            "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "read-token", :id "PXnlPwcrsRP"}
-                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "action", :id "4gIea0IK_oh"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192521310, :text "action", :id "6XbV_kAbb"}
                            "r" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154854356, :id "MMYXEmEBnH"
+                            :type :expr, :by "rJG4IHzWf", :at 1552192522528, :id "ce_3bieI6"
                             :data {
-                             "D" {:type :leaf, :by "rJG4IHzWf", :at 1552154860530, :text "{}", :id "VI6-S5CJN"}
-                             "L" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154860902, :id "CRYx6QbHlM"
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192524756, :text ":data", :id "3xs_VdgTld"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192527252, :text "context", :id "wRzXvdk6c0"}
+                            }
+                           }
+                          }
+                         }
+                         "x" {:type :leaf, :by "rJG4IHzWf", :at 1552191990726, :text "param", :id "sUzNf4eqGa"}
+                         "y" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "PMFkM38nx6"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text "{}", :id "PlmrTN-gwI"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "Ku2gxb-JLI"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text ":props", :id "KJp_eDSBxs"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text "props", :id "jWN9osjtvD"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "w13WwpiZRT"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552193852500, :text ":value", :id "-AjRbqBoTe"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "FsahiW4VKA"
                               :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154861967, :text ":text", :id "g69GKq9q5r"}
-                               "j" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552154862688, :id "t7AmuFZK8M"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154863276, :text ":value", :id "Hlp2siU8Y2"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154863507, :text "e", :id "xUr2HIi8QJ"}
-                                }
-                               }
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text ":value", :id "iQjT619TXu"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text "e", :id "cfq1rDrdmc"}
                               }
                              }
-                             "P" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154864760, :id "tAmJ9EfUp"
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "uZdS0aVE8g"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text ":event", :id "a7W353G9nR"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "oWDWUCJzFb"
                               :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154865584, :text ":event", :id "tAmJ9EfUpleaf"}
-                               "j" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552154865827, :id "D2PrXUafQR"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154867498, :text ":event", :id "G9GTF1rhNl"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154867731, :text "e", :id "mP0ujQWEs"}
-                                }
-                               }
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text ":event", :id "FWCPW7nGdr"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text "e", :id "TuBNuC1T1hV"}
                               }
                              }
-                             "T" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "JlGWvhJNeu3"
+                            }
+                           }
+                           "x" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "-0IBcO3bEtZ"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text ":data", :id "8aQ4TfPhCxW"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192515460, :id "CL6kn-4wwYw"
                               :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text ":data", :id "ZV5aZdq3kn4"}
-                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "context", :id "arwc_Lggmp_"}
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text ":data", :id "6OxEV8_--f_"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192515460, :text "context", :id "mIJwMfl_wlL"}
                               }
                              }
                             }
                            }
                           }
                          }
-                         "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "props", :id "3WttCIXXL3P"}
-                         "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "param", :id "ClC2-h8GmvC"}
                         }
                        }
                       }
@@ -4897,6 +5096,144 @@
              }
             }
            }
+           "y" {
+            :type :expr, :by "rJG4IHzWf", :at 1552192456113, :id "C5cjUbtf6b"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192457371, :text "event-map", :id "C5cjUbtf6bleaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "9SJdMUxURJ"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "->>", :id "oO-TzWOteC"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "6e8PpIyIJu"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text ":event", :id "l6JObYslUh"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "markup", :id "_pDoRhceDC"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "AlbfpmqYmk"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "map", :id "kRi_eNWIfx"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "V1BGw1BRmN"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "fn", :id "2wxb6Y8qW3"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "AQu4S5PTh8"
+                    :data {
+                     "T" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "fzzxnynebU"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "[]", :id "w6vZWV3v0s"}
+                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "name", :id "g14JGDNHB4"}
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "action", :id "4-qNjMwia1"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "tyzJplHxIdf"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "[]", :id "YDq80HYW071"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "name", :id "ELmMHiIBtm5"}
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "UGmbRTMlydZ"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "fn", :id "UsRl13BSkgX"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "_tMApciRQ3K"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "e", :id "stw8rakHAmq"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "d!", :id "gjXKRnqtV-u"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "m!", :id "h8DU5ejlFT1"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "hB1ANgxgM8v"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "on-action", :id "XJDZrf2gbRk"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "d!", :id "dAmlai8oLUH"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "F0xMLnxHVz9"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "read-token", :id "SJzVMolpKl5"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "action", :id "mfnGZVIJKfE"}
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "UtMZXWJbRYU"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text ":data", :id "o0n65zlnohw"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "context", :id "vAfhhpqdVHL"}
+                            }
+                           }
+                          }
+                         }
+                         "x" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "param", :id "_R5ivfjiBLp"}
+                         "y" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552192462207, :id "M4jglqMhRN"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192462599, :text "{}", :id "btYLdqpro3"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192462911, :id "OY_A_jTapP"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192464847, :text ":event", :id "GRCsAgIbLZ"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192467513, :id "oWDWkiXLyP"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192468337, :text ":event", :id "_tA4fUR0Cx"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192470974, :text "e", :id "hgSnmuOsgb"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192471952, :id "Qs7tC6RTRX"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192472948, :text ":props", :id "Qs7tC6RTRXleaf"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192473692, :text "props", :id "-wwwP8gges"}
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552192474418, :id "3hDy3GNumM"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192475044, :text ":data", :id "3hDy3GNumMleaf"}
+                             "j" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552192475283, :id "AjR9TW5EWO"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192475834, :text ":data", :id "Qjy4FXqv8B"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192477925, :text "context", :id "6xIOAPiQjm"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "kMZU75f6kw7"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "into", :id "PMuo6Yi71Kr"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552192458891, :id "Qzi-nEiZ4Jt"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552192458891, :text "{}", :id "Ggujf3jNbZk"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "r" {
@@ -4983,100 +5320,7 @@
                 :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "5ONiDRYzWA"
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text ":on", :id "gbeMozJKUE"}
-                 "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "jiPHrKIWoY"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "->>", :id "fdlLr7rMmy"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "3OUOGqZb2V"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text ":event", :id "oDGGkOXBz7"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "markup", :id "iGL1fYs8C0"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "CmptR97RZi"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "map", :id "suLTsEbvOw"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "41-dTuVL77"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "fn", :id "vMtYtu_NxK"}
-                       "j" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "9WuUoOzJUf"
-                        :data {
-                         "T" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "8mcE9L5Vl6"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "[]", :id "NsAlamrHSGB"}
-                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "name", :id "B_aeAYcSaqp"}
-                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "action", :id "ppVb2BxpsA0"}
-                          }
-                         }
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "J-Pu1avarBd"
-                        :data {
-                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "[]", :id "wnGQDqqGmiE"}
-                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "name", :id "Fp9LZw-LwnC"}
-                         "r" {
-                          :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "vLjLl8r14Mc"
-                          :data {
-                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "fn", :id "0Pg4su80sz7"}
-                           "j" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "bBJ13yJRujb"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "e", :id "7GD1zDcMG-y"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "d!", :id "S5yIzKTCvmV"}
-                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "m!", :id "Qzs6QOk0YMr"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "YAqG4e2_Mvt"
-                            :data {
-                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "on-action", :id "CozZdIH0Yfm"}
-                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "d!", :id "SCeJQjOkj1o"}
-                             "r" {
-                              :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "xu1uKmwpP35"
-                              :data {
-                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "read-token", :id "JsGb3neDTIW"}
-                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "action", :id "WNKuPQpXmeT"}
-                               "r" {
-                                :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "sJ-eDopc5cU"
-                                :data {
-                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text ":data", :id "tpFJTeFu-G1"}
-                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "context", :id "qdN9NMDEdyJ"}
-                                }
-                               }
-                              }
-                             }
-                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "props", :id "4OkgZTRGN23"}
-                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "param", :id "o8_H7jQE-oI"}
-                            }
-                           }
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "Cj9pPV9YZFo"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "into", :id "IijbgTyznBE"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "RTHOGbC2m_x"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "{}", :id "gTq3znB5uhf"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552192454568, :text "event-map", :id "8LzxLQldw"}
                 }
                }
               }

--- a/calcit.edn
+++ b/calcit.edn
@@ -2639,6 +2639,33 @@
              }
             }
            }
+           "X" {
+            :type :expr, :by "rJG4IHzWf", :at 1552152552203, :id "WqyB30QMo"
+            :data {
+             "T" {
+              :type :expr, :by "rJG4IHzWf", :at 1552152552427, :id "XBHjswCpKE"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152557618, :text "string/starts-with?", :id "WqyB30QMoleaf"}
+               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152558134, :text "x", :id "amLyMYVNxB"}
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152559627, :text "\":", :id "NmboQ6KOe"}
+              }
+             }
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552152560318, :id "i9QSD9vjyb"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152566499, :text "keyword", :id "i9QSD9vjybleaf"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552152567155, :id "glGK9OAUmW"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152567494, :text "subs", :id "hwEGN9m4c"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152572852, :text "x", :id "7Az4WB_rT"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152573454, :text "1", :id "aozezDAs5G"}
+                }
+               }
+              }
+             }
+            }
+           }
            "b" {
             :type :expr, :by "rJG4IHzWf", :at 1549976928968, :id "_8Paw1eCa"
             :data {
@@ -2662,6 +2689,27 @@
                  "r" {:type :leaf, :by "rJG4IHzWf", :at 1550384395687, :text "1", :id "nF6mHKqjEP"}
                 }
                }
+              }
+             }
+            }
+           }
+           "f" {
+            :type :expr, :by "rJG4IHzWf", :at 1552152900876, :id "bzlxqunVsQ"
+            :data {
+             "T" {
+              :type :expr, :by "rJG4IHzWf", :at 1552152900876, :id "KzqCos0Ztn"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "string/starts-with?", :id "6tFfJ2bWmm"}
+               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "x", :id "-yByccWr35"}
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152903754, :text "\"", :id "3ngYwua0xY"}
+              }
+             }
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552152900876, :id "dSHXgHIsQq"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "subs", :id "loTviY0R02"}
+               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "x", :id "YjejbbeJ6T"}
+               "r" {:type :leaf, :by "rJG4IHzWf", :at 1552152900876, :text "1", :id "ib9wFsaJZz"}
               }
              }
             }
@@ -2713,37 +2761,10 @@
              }
             }
            }
-           "j" {
-            :type :expr, :by "rJG4IHzWf", :at 1551374555651, :id "CRZ6CGv7VJ"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374555651, :text "action", :id "WobgLDAkJ1"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1551374797035, :id "3F5mypYJYS"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374797035, :text "read-token", :id "l-Dq-9VMFi"}
-               "j" {
-                :type :expr, :by "rJG4IHzWf", :at 1551374797035, :id "bip7RuqiGE"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374797035, :text "get", :id "UQIbFOlS1O"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374797035, :text "props", :id "wUukCHJcCN"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551374797035, :text "\"action", :id "rmxipudLth"}
-                }
-               }
-               "r" {
-                :type :expr, :by "rJG4IHzWf", :at 1551374797035, :id "HJTXqjpUzP"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374797035, :text ":data", :id "wxIl8pr4Xd"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374797035, :text "context", :id "k3BBjIFbbw"}
-                }
-               }
-              }
-             }
-            }
-           }
            "r" {
             :type :expr, :by "rJG4IHzWf", :at 1551589077502, :id "4sNfcoQFFK"
             :data {
-             "D" {:type :leaf, :by "rJG4IHzWf", :at 1551589078366, :text "data", :id "WYXjZr5nn"}
+             "D" {:type :leaf, :by "rJG4IHzWf", :at 1552153796728, :text "param", :id "WYXjZr5nn"}
              "T" {
               :type :expr, :by "rJG4IHzWf", :at 1551589076996, :id "u1UM8G8TBB"
               :data {
@@ -2847,40 +2868,97 @@
                 }
                }
                "r" {
-                :type :expr, :by "rJG4IHzWf", :at 1551374539072, :id "DeNUIoh8F"
+                :type :expr, :by "rJG4IHzWf", :at 1552153668881, :id "C37IEMCQR"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374541067, :text ":on-click", :id "DeNUIoh8Fleaf"}
-                 "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551374541486, :id "ta6jstXdfO"
+                 "D" {:type :leaf, :by "rJG4IHzWf", :at 1552154186066, :text ":on", :id "EWTuoqplxb"}
+                 "L" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552153723235, :id "FYHwlzSdoa"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374541851, :text "if", :id "trW6N7HLbf"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153724599, :text "->>", :id "s328BfH9i"}
                    "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551374560693, :id "Bq2CUL5W4"
+                    :type :expr, :by "rJG4IHzWf", :at 1552153958858, :id "eAYRosqgN2"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374562399, :text "some?", :id "ghTuIX1v-m"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374562815, :text "action", :id "v-BCzoKoy"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153958858, :text ":event", :id "vm04xZ9K9L"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153958858, :text "markup", :id "ojHtROWlme"}
                     }
                    }
                    "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551374563489, :id "8Ni_X4_GG-"
+                    :type :expr, :by "rJG4IHzWf", :at 1552153726904, :id "U3u0Pu1v_"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374563913, :text "fn", :id "8Ni_X4_GG-leaf"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153727534, :text "map", :id "_X-srgzS5Z"}
                      "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1551374565023, :id "1367k-RKBF"
+                      :type :expr, :by "rJG4IHzWf", :at 1552153727924, :id "j8SEYLhbzs"
                       :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374565324, :text "e", :id "M8v8HPpT3"}
-                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374566015, :text "d!", :id "uv8uT_eVKz"}
-                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1551374566663, :text "m!", :id "ofxmo4mYjd"}
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153729074, :text "fn", :id "AfRLFce74l"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552153729402, :id "0Fj5V7n1TX"
+                        :data {
+                         "T" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552153729743, :id "svJzMZw-3"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153730076, :text "[]", :id "7OO8UpGHEL"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153914577, :text "name", :id "3Cn1tuLDmn"}
+                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552153858661, :text "action", :id "aS7A3iOUOz"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552153748021, :id "kPyW2Ogu_0"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153749310, :text "[]", :id "kPyW2Ogu_0leaf"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153916502, :text "name", :id "1FXQOqiP_4"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552153767677, :id "d5cMO7KQR"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153768006, :text "fn", :id "o0VQ2wquq"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552153768619, :id "HrhvZ3YbI"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153768983, :text "e", :id "F-2ZamT-Vs"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153770217, :text "d!", :id "EHPWS80G-"}
+                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552153773715, :text "m!", :id "bkpyU1Z4Y0"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552153780325, :id "ihyz4WRH9"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153783709, :text "on-action", :id "ihyz4WRH9leaf"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153785244, :text "d!", :id "EFMkKswV1O"}
+                             "n" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552153832211, :id "zWzm4PIKxH"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text "read-token", :id "jR9ZkSwXrq"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text "action", :id "FGNkj2U-HZ"}
+                               "r" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552153832211, :id "tjTGaN87rj"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text ":data", :id "yFLFD9ffjS"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552153832211, :text "context", :id "vfB-dTtI0s"}
+                                }
+                               }
+                              }
+                             }
+                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552153788260, :text "props", :id "5meF7FbQH"}
+                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552153794170, :text "param", :id "q5oF8RxTx"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
                       }
                      }
-                     "r" {
-                      :type :expr, :by "rJG4IHzWf", :at 1551374567547, :id "bLOWTd8vh"
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552153753388, :id "pXYUs-QA7g"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153756352, :text "into", :id "pXYUs-QA7gleaf"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552153756630, :id "daUUzKZln"
                       :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374580094, :text "on-action", :id "bLOWTd8vhleaf"}
-                       "b" {:type :leaf, :by "rJG4IHzWf", :at 1551374581400, :text "d!", :id "2jfcXvLRFX"}
-                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374571277, :text "action", :id "6bhV_VjYJX"}
-                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1551374572707, :text "props", :id "BWfS9EaIi"}
-                       "v" {:type :leaf, :by "rJG4IHzWf", :at 1551589087112, :text "data", :id "eMc0MteuEf"}
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153756969, :text "{}", :id "iDi-CXXsCz"}
                       }
                      }
                     }
@@ -2974,37 +3052,10 @@
              }
             }
            }
-           "r" {
-            :type :expr, :by "rJG4IHzWf", :at 1551029184590, :id "zfwk7w3wY"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551029185330, :text "action", :id "zfwk7w3wYleaf"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1551374787683, :id "L_o_rZxr7e"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374787683, :text "read-token", :id "vlX_9Eat7X"}
-               "j" {
-                :type :expr, :by "rJG4IHzWf", :at 1551374787683, :id "YMDqs60Dzk"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374787683, :text "get", :id "nns9TXOmp0"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374787683, :text "props", :id "2zb3Wzcbxa"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551374791143, :text "\"action", :id "Ta8d-_wltr"}
-                }
-               }
-               "r" {
-                :type :expr, :by "rJG4IHzWf", :at 1551374787683, :id "V0Iz9D0zpr"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551374787683, :text ":data", :id "5y3Z_Cm5Rq"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551374787683, :text "context", :id "szdecWkakL"}
-                }
-               }
-              }
-             }
-            }
-           }
            "v" {
             :type :expr, :by "rJG4IHzWf", :at 1551589096735, :id "ihho2mWvs2"
             :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589096735, :text "data", :id "AAt5I11NDg"}
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552153929631, :text "param", :id "AAt5I11NDg"}
              "j" {
               :type :expr, :by "rJG4IHzWf", :at 1551589096735, :id "XFpzC30HuB"
               :data {
@@ -3014,7 +3065,7 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589096735, :text "get", :id "__1ybmzIYP"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589096735, :text "props", :id "cJnEnI2yZK"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551589096735, :text "\"data", :id "S_Dts_UERp"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154720117, :text "\"param", :id "S_Dts_UERp"}
                 }
                }
                "r" {
@@ -3109,30 +3160,100 @@
                  }
                 }
                }
-               "v" {
-                :type :expr, :by "rJG4IHzWf", :at 1549952592107, :id "MVOe1evvT4"
+               "x" {
+                :type :expr, :by "rJG4IHzWf", :at 1552153902966, :id "9PD5t3_bjc"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1549952596805, :text ":on-click", :id "MVOe1evvT4leaf"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154178814, :text ":on", :id "O7CbXKI9TJ"}
                  "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1549952597050, :id "gWF1iLoYBw"
+                  :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "fGQN_mTxMD"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1549952597262, :text "fn", :id "la35MaWe3O"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "->>", :id "rZpXOSpEip"}
                    "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1549952597997, :id "4rmvn__ktv"
+                    :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "8u7pQpB6od"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1549952598244, :text "e", :id "FWWDXmOn4"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1549952598761, :text "d!", :id "2FAWKSZiEq"}
-                     "r" {:type :leaf, :by "rJG4IHzWf", :at 1549952600125, :text "m!", :id "SsoVdKxeWw"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text ":event", :id "F5sGNDnXc_"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "markup", :id "Cl1QIjzXuX"}
                     }
                    }
                    "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1549952600967, :id "f5bCafMaBw"
+                    :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "Y-ma4d4Fhm"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1549952603442, :text "on-action", :id "f5bCafMaBwleaf"}
-                     "Z" {:type :leaf, :by "rJG4IHzWf", :at 1551029241037, :text "d!", :id "BRVumqAp_"}
-                     "f" {:type :leaf, :by "rJG4IHzWf", :at 1551029188558, :text "action", :id "4TD0PcpYA"}
-                     "r" {:type :leaf, :by "rJG4IHzWf", :at 1549952620444, :text "props", :id "wfvgb6nPB"}
-                     "v" {:type :leaf, :by "rJG4IHzWf", :at 1551589098601, :text "data", :id "0tBwX-LDUx"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "map", :id "KFUOm6egQt"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "HNiWmDqTr_"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "fn", :id "XigbDIKe5O"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "J8tgJf-f_w"
+                        :data {
+                         "T" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "3RE3yXg-0U"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "[]", :id "G_4jfB7bAh"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "name", :id "pavhgeW9bn"}
+                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "action", :id "072Gv-cF5i"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "3OUtcgCPXOV"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "[]", :id "bISe2EudqXZ"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "name", :id "9_ag_4cZEo4"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "rQUHt497SKD"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "fn", :id "9zhDFhodK_5"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "8BRpWZORyPl"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "e", :id "RkJtoBFs_8b"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "d!", :id "42LDY7yip0q"}
+                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "m!", :id "JxIQF_8B_uM"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "4qqDKkI5oi6"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "on-action", :id "7M7Fovxcvpz"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "d!", :id "7GkvNsyarsH"}
+                             "r" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "GK7i3SK8fuC"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "read-token", :id "kSj8syto6DQ"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "action", :id "uhesVK2LZDD"}
+                               "r" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "hHubAFit0GT"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text ":data", :id "xx_50TIpq_l"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "context", :id "tJ4nNFyiYuY"}
+                                }
+                               }
+                              }
+                             }
+                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "props", :id "UX7TJZRjU58"}
+                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "param", :id "2hpF4CwIrGq"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "ZbPzgin_I8O"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "into", :id "8guzPE56GYS"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154920990, :id "zxDPFfRftWR"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154920990, :text "{}", :id "dBXsE371fbl"}
+                      }
+                     }
                     }
                    }
                   }
@@ -3458,6 +3579,33 @@
              }
             }
            }
+           "v" {
+            :type :expr, :by "rJG4IHzWf", :at 1552154955304, :id "xyxO2jpHXU"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text "param", :id "QcecoUOWjy"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552154955304, :id "P1ZSksCr1M"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text "read-token", :id "IAHM8kvUJi"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154955304, :id "b5egBNnQ1x"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text "get", :id "taEJE5N90Z"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text "props", :id "tgWDd_IzvT"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text "\"param", :id "z5Nly5iPll"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154955304, :id "1NyqFttj38"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text ":data", :id "0gAfeEVINL"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154955304, :text "context", :id "roFYuzgTBg"}
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "T" {
@@ -3532,6 +3680,106 @@
                     :data {
                      "T" {:type :leaf, :by "rJG4IHzWf", :at 1550943813895, :text ":style", :id "lstBqXsCcmr"}
                      "j" {:type :leaf, :by "rJG4IHzWf", :at 1550943813895, :text "markup", :id "nskgNJ_Z1Ko"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154934541, :id "2wY_gcZaO"
+                :data {
+                 "D" {:type :leaf, :by "rJG4IHzWf", :at 1552154936749, :text ":on", :id "NxWOcmQjCP"}
+                 "T" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "OMfHVigJrT"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "->>", :id "OnfOV7b-ov"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "vFTLY5Lted"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text ":event", :id "coS3MPvxiT"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "markup", :id "xVUUaRnDVF"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "0yAcNhfIUX"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "map", :id "N3yo6NDosH"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "aPSlekMkQE"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "fn", :id "MCWiiBz_mu"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "9pskgHax0-"
+                        :data {
+                         "T" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "0nCiYf-xn4"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "[]", :id "xDH7lHzpYo"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "name", :id "6q-uj6jMu6"}
+                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "action", :id "MJZDV30oxR"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "oArHGX5WbI"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "[]", :id "tJ17Lhdxag2"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "name", :id "0nr896qDXvL"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "G8QPRABU35Y"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "fn", :id "vNeif51sSBr"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "H5EY6K7rZVi"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "e", :id "M8vzGLgCG5q"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "d!", :id "nYpy09klkQx"}
+                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "m!", :id "xhUUKRxT0LH"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "H6SLv2N0z8l"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "on-action", :id "JBGpSJ1S0Pq"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "d!", :id "CynfiiFzM2t"}
+                             "r" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "SVyvqXwSSr5"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "read-token", :id "cKpy57QePqk"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "action", :id "yBQkteIfQRP"}
+                               "r" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "V3ZoQQmkJJJ"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text ":data", :id "TNkSNtoBZQV"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "context", :id "l8EMQ36UQud"}
+                                }
+                               }
+                              }
+                             }
+                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "props", :id "ob3pZn3jRSk"}
+                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "param", :id "kl33xao4uvp"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "o-FjajSPKVg"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "into", :id "8YEgHtSAl6d"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154933848, :id "VsFSw-kTAf7"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154933848, :text "{}", :id "I7pJWiV4MQJ"}
+                      }
+                     }
                     }
                    }
                   }
@@ -3675,37 +3923,10 @@
              }
             }
            }
-           "y" {
-            :type :expr, :by "rJG4IHzWf", :at 1551528515024, :id "fQoIQ2Fhld"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text "action", :id "R2ADTY5YOX"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1551528515024, :id "F9X74oCJ__"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text "read-token", :id "2vw7KfTq91"}
-               "j" {
-                :type :expr, :by "rJG4IHzWf", :at 1551528515024, :id "LGTAyW76mn"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text "get", :id "W1Vobr42IJ"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text "props", :id "8wqlkMivLA"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text "\"action", :id "zzJcfx9G5C"}
-                }
-               }
-               "r" {
-                :type :expr, :by "rJG4IHzWf", :at 1551528515024, :id "cnyfjoV2ip"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text ":data", :id "Y4UdFul75r"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1551528515024, :text "context", :id "_yxkQNzKcX"}
-                }
-               }
-              }
-             }
-            }
-           }
            "yT" {
             :type :expr, :by "rJG4IHzWf", :at 1551589116406, :id "plMrDBt-GT"
             :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589116406, :text "data", :id "v79DMI0Cwd"}
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154703241, :text "param", :id "v79DMI0Cwd"}
              "j" {
               :type :expr, :by "rJG4IHzWf", :at 1551589116406, :id "vBp32XZvie"
               :data {
@@ -3715,7 +3936,7 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589116406, :text "get", :id "7YTiUy3r94"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589116406, :text "props", :id "vd_tEYCK2Q"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551589116406, :text "\"data", :id "3UEfLgW6HD"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154704881, :text "\"param", :id "3UEfLgW6HD"}
                 }
                }
                "r" {
@@ -3822,30 +4043,100 @@
                  }
                 }
                }
-               "v" {
-                :type :expr, :by "rJG4IHzWf", :at 1551029267060, :id "Qkd2AlYyE-"
+               "x" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "vdtg0vjNF2"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551029268429, :text ":on-click", :id "Qkd2AlYyE-leaf"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text ":on", :id "6VsUgzVrcZ"}
                  "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551029269245, :id "OEkkfYDaIO"
+                  :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "7p63Ecrtjh"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551029269543, :text "fn", :id "VSLjmGUZ_"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "->>", :id "gHlmESiIT3"}
                    "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551029269825, :id "eprQo-MV9L"
+                    :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "xRb84fQnHf"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551029270047, :text "e", :id "7FgfwS-00F"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551029270590, :text "d!", :id "qVyQtMyg0B"}
-                     "r" {:type :leaf, :by "rJG4IHzWf", :at 1551029271282, :text "m!", :id "YITndVbh1Y"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text ":event", :id "LJFQD8AswK"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "markup", :id "mA6omqXXZ6"}
                     }
                    }
                    "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551029271748, :id "R08PY4a5AO"
+                    :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "A9RGAPcFWU"
                     :data {
-                     "D" {:type :leaf, :by "rJG4IHzWf", :at 1551029292994, :text "on-action", :id "Kk2MNmN-q"}
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551029272876, :text "d!", :id "R08PY4a5AOleaf"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551029273770, :text "action", :id "KaWMOjOPBS"}
-                     "r" {:type :leaf, :by "rJG4IHzWf", :at 1551029298294, :text "props", :id "s_Sq8hoRZW"}
-                     "v" {:type :leaf, :by "rJG4IHzWf", :at 1551589118094, :text "data", :id "33Gjfkq8x"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "map", :id "zXtFatLRDl"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "P7Pp-fcMR6"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "fn", :id "ydkqodSZJs"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "wmlnrLclyI"
+                        :data {
+                         "T" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "P8p9-H1bRx"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "[]", :id "Ki2oUW-p5K"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "name", :id "IReN6vn6ddJ"}
+                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "action", :id "zqduZ97ikIo"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "Z8RX9fE614w"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "[]", :id "CozBRUeGFLo"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "name", :id "dII_S-eldP-"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "4aW_Qxs6aG5"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "fn", :id "u83uC0LDV0d"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "40Uz8p2Craf"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "e", :id "FjIV8XZ1Yln"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "d!", :id "8xZ69mBMEWZ"}
+                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "m!", :id "2Gg7nTEjnAi"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "4jbuctq6IY5"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "on-action", :id "sTBxfc8X25t"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "d!", :id "n5SJFw1OtWm"}
+                             "r" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "vOLSP_rEfkN"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "read-token", :id "7bDI-lwkGYw"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "action", :id "Zs867TGOxCX"}
+                               "r" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "A8xOVDxBOgg"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text ":data", :id "uCUrN8MsN9F"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "context", :id "8QNOT5tMx-V"}
+                                }
+                               }
+                              }
+                             }
+                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "props", :id "SniZptUv9o-"}
+                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "param", :id "q3ecTWqdpnz"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "LROUdYRGBzP"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "into", :id "8aL9mOWn6tO"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154692481, :id "j2RrmpiZJ2T"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154692481, :text "{}", :id "g_VzCnCphkh"}
+                      }
+                     }
                     }
                    }
                   }
@@ -3957,44 +4248,10 @@
              }
             }
            }
-           "r" {
-            :type :expr, :by "rJG4IHzWf", :at 1551588256248, :id "BUG46_bDyV"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text "action", :id "1vF4VkhqYr"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1551588270781, :id "UTVEGg0yR"
-              :data {
-               "D" {:type :leaf, :by "rJG4IHzWf", :at 1551588272657, :text "or", :id "eQEsAYKJMH"}
-               "T" {
-                :type :expr, :by "rJG4IHzWf", :at 1551588256248, :id "-F-D6gqBar"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text "read-token", :id "NHifKw9Gqz"}
-                 "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551588256248, :id "5ndFtzxvDI"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text "get", :id "uAkzkVVO4E"}
-                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text "props", :id "0STpf-vGJK"}
-                   "r" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text "\"action", :id "N2MKn5lF8i"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551588256248, :id "4nd9dkZ2dd"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text ":data", :id "FYi49nAlWL"}
-                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1551588256248, :text "context", :id "oIXt5mPL4n"}
-                  }
-                 }
-                }
-               }
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1551588275461, :text ":input", :id "elwQCUFpUJ"}
-              }
-             }
-            }
-           }
            "t" {
             :type :expr, :by "rJG4IHzWf", :at 1551589193411, :id "DjlTwdgvYm"
             :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589193411, :text "data", :id "QxuPd_yO9A"}
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154889237, :text "param", :id "QxuPd_yO9A"}
              "j" {
               :type :expr, :by "rJG4IHzWf", :at 1551589193411, :id "va_JVWPyFr"
               :data {
@@ -4004,7 +4261,7 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589193411, :text "get", :id "r-F24efOFc"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589193411, :text "props", :id "swJpcbNZag"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551589193411, :text "\"data", :id "0VjcATnxpi"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154891872, :text "\"param", :id "0VjcATnxpi"}
                 }
                }
                "r" {
@@ -4012,74 +4269,6 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589193411, :text ":data", :id "RItc4H8LFD"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589193411, :text "context", :id "q7TyezHjzL"}
-                }
-               }
-              }
-             }
-            }
-           }
-           "v" {
-            :type :expr, :by "rJG4IHzWf", :at 1550856803467, :id "pbjyFe2U78"
-            :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1550856805454, :text "listener", :id "pbjyFe2U78leaf"}
-             "j" {
-              :type :expr, :by "rJG4IHzWf", :at 1550856806011, :id "TdPR7xUg4r"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "fn", :id "Z0Kt4syzhl"}
-               "j" {
-                :type :expr, :by "rJG4IHzWf", :at 1550856806011, :id "0HpgeogSku"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "e", :id "Qa02yiih4G"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "d!", :id "MbfFhLnxBm"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "m!", :id "7R5P0unZP8"}
-                }
-               }
-               "r" {
-                :type :expr, :by "rJG4IHzWf", :at 1550856806011, :id "4wDVmnJ5oG"
-                :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "on-action", :id "liJY88tENm"}
-                 "b" {:type :leaf, :by "rJG4IHzWf", :at 1551029446702, :text "d!", :id "2ucdQgOZf1"}
-                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "action", :id "6RP1VMw764"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1550856806011, :text "props", :id "3gF_hSVIzG"}
-                 "v" {
-                  :type :expr, :by "rJG4IHzWf", :at 1551589157823, :id "mpLBrZ60j"
-                  :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589159425, :text "{}", :id "XwTmvy8U9y"}
-                   "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551589159783, :id "Rao47h_3O5"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589168592, :text ":text", :id "In5Nb7tJd"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1551589168841, :id "8TM4dbAsi4"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589169491, :text ":value", :id "yzOFMKwVM8"}
-                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589169745, :text "e", :id "8C6oAdL3-"}
-                      }
-                     }
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551589170579, :id "DHWxvyw-V"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589171442, :text ":event", :id "DHWxvyw-Vleaf"}
-                     "j" {
-                      :type :expr, :by "rJG4IHzWf", :at 1551589172602, :id "reoRexdIwj"
-                      :data {
-                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589174344, :text ":event", :id "l6gIqxJMe"}
-                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589174570, :text "e", :id "7OpHnDhLwr"}
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "rJG4IHzWf", :at 1551589176211, :id "LTwX4QFLU"
-                    :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589178181, :text ":data", :id "LTwX4QFLUleaf"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589181273, :text "data", :id "n0XpELTl4"}
-                    }
-                   }
-                  }
-                 }
                 }
                }
               }
@@ -4106,6 +4295,138 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551030693488, :text ":data", :id "Pk_qKg5xdm"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551030693488, :text "context", :id "mFi2GJFddi"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "y" {
+            :type :expr, :by "rJG4IHzWf", :at 1552154767883, :id "TKKjGw45Kd"
+            :data {
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154772219, :text "event-map", :id "TKKjGw45Kdleaf"}
+             "j" {
+              :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "Eo-seUQ_0g"
+              :data {
+               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "->>", :id "FQZIE4SRQT"}
+               "j" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "2sZOfDxtJL"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text ":event", :id "gjpyIRj6Ja"}
+                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "markup", :id "lbYzbr646B"}
+                }
+               }
+               "r" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "zcrf0PPEcH"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "map", :id "-uQn1FA-Or"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "brxRE0ghn7"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "fn", :id "2-ESdfe0jR"}
+                   "j" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "j4r4YZFUzx"
+                    :data {
+                     "T" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "-ki-bnwFIK"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "[]", :id "QXfrBnyZxxp"}
+                       "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "name", :id "ZO3DmnXM8iq"}
+                       "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "action", :id "LQOmyX4nNxD"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "haWEHg6tRGC"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "[]", :id "W1v6vZT6S5b"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "name", :id "xCFrjy5_9S6"}
+                     "r" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "Hz523XTElOo"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "fn", :id "J6JHD-iZd92"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "qTnpPCBl0ug"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "e", :id "72EZbf-eQIF"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "d!", :id "muV7D-2duc6"}
+                         "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "m!", :id "ZaLzUpcarW9"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "jAzflS2k2LO"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "on-action", :id "zkJXYeoZ4V6"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "d!", :id "zvwJvafywIe"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "4Xp2bRI7UN2"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "read-token", :id "PXnlPwcrsRP"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "action", :id "4gIea0IK_oh"}
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154854356, :id "MMYXEmEBnH"
+                            :data {
+                             "D" {:type :leaf, :by "rJG4IHzWf", :at 1552154860530, :text "{}", :id "VI6-S5CJN"}
+                             "L" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154860902, :id "CRYx6QbHlM"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154861967, :text ":text", :id "g69GKq9q5r"}
+                               "j" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552154862688, :id "t7AmuFZK8M"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154863276, :text ":value", :id "Hlp2siU8Y2"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154863507, :text "e", :id "xUr2HIi8QJ"}
+                                }
+                               }
+                              }
+                             }
+                             "P" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154864760, :id "tAmJ9EfUp"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154865584, :text ":event", :id "tAmJ9EfUpleaf"}
+                               "j" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552154865827, :id "D2PrXUafQR"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154867498, :text ":event", :id "G9GTF1rhNl"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154867731, :text "e", :id "mP0ujQWEs"}
+                                }
+                               }
+                              }
+                             }
+                             "T" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "JlGWvhJNeu3"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text ":data", :id "ZV5aZdq3kn4"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "context", :id "arwc_Lggmp_"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                         "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "props", :id "3WttCIXXL3P"}
+                         "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "param", :id "ClC2-h8GmvC"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "W8io5ZSE9Kl"
+                :data {
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "into", :id "EOB4KWGVdy1"}
+                 "j" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552154769326, :id "8lm4UeA8nOf"
+                  :data {
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154769326, :text "{}", :id "MbVMzliolyl"}
+                  }
+                 }
                 }
                }
               }
@@ -4172,11 +4493,11 @@
                    }
                   }
                  }
-                 "r" {
-                  :type :expr, :by "rJG4IHzWf", :at 1550856280828, :id "eQUX5yVpD"
+                 "v" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552154777488, :id "16GydDbczH"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1550856283043, :text ":on-input", :id "eQUX5yVpDleaf"}
-                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1550856802125, :text "listener", :id "-BZMXyg3U"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154778220, :text ":on", :id "16GydDbczHleaf"}
+                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154781007, :text "event-map", :id "cD-2TZirp"}
                   }
                  }
                 }
@@ -4238,11 +4559,11 @@
                    }
                   }
                  }
-                 "r" {
-                  :type :expr, :by "rJG4IHzWf", :at 1550856280828, :id "eQUX5yVpD"
+                 "v" {
+                  :type :expr, :by "rJG4IHzWf", :at 1552154783332, :id "FOobcw5P9I"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1550856283043, :text ":on-input", :id "eQUX5yVpDleaf"}
-                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1550856802125, :text "listener", :id "-BZMXyg3U"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154783332, :text ":on", :id "QHu5GoekL7"}
+                   "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154783332, :text "event-map", :id "zUnPI9kylR"}
                   }
                  }
                 }
@@ -4549,25 +4870,10 @@
              }
             }
            }
-           "v" {
-            :type :expr, :by "rJG4IHzWf", :at 1551029328027, :id "5XrT9CNbC"
-            :data {
-             "D" {:type :leaf, :by "rJG4IHzWf", :at 1551029329509, :text "action", :id "XrUwG-L9BD"}
-             "T" {
-              :type :expr, :by "rJG4IHzWf", :at 1551029327269, :id "hcazclYr2q"
-              :data {
-               "T" {:type :leaf, :by "rJG4IHzWf", :at 1551029327269, :text "get", :id "mDI6GfNJCO"}
-               "j" {:type :leaf, :by "rJG4IHzWf", :at 1551029327269, :text "props", :id "Q_6yJsJKr2"}
-               "r" {:type :leaf, :by "rJG4IHzWf", :at 1551029327269, :text "\"action", :id "hAjVIzaKgO"}
-               "v" {:type :leaf, :by "rJG4IHzWf", :at 1551029327269, :text "\"link-click", :id "QKVkyAklvE"}
-              }
-             }
-            }
-           }
            "x" {
             :type :expr, :by "rJG4IHzWf", :at 1551589106480, :id "KD1u4gSXwr"
             :data {
-             "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589106480, :text "data", :id "PKdOj3pFU2"}
+             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154735921, :text "param", :id "PKdOj3pFU2"}
              "j" {
               :type :expr, :by "rJG4IHzWf", :at 1551589106480, :id "vWGrsrAr_O"
               :data {
@@ -4577,7 +4883,7 @@
                 :data {
                  "T" {:type :leaf, :by "rJG4IHzWf", :at 1551589106480, :text "get", :id "NvixqW592m"}
                  "j" {:type :leaf, :by "rJG4IHzWf", :at 1551589106480, :text "props", :id "K1ZfCsKvMp"}
-                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1551589106480, :text "\"data", :id "tOLUHhslj6"}
+                 "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154737880, :text "\"param", :id "tOLUHhslj6"}
                 }
                }
                "r" {
@@ -4673,30 +4979,100 @@
                  }
                 }
                }
-               "x" {
-                :type :expr, :by "rJG4IHzWf", :at 1549989131846, :id "ys5Q3BjgqX"
+               "y" {
+                :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "5ONiDRYzWA"
                 :data {
-                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1549989133309, :text ":on-click", :id "ys5Q3BjgqXleaf"}
+                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text ":on", :id "gbeMozJKUE"}
                  "j" {
-                  :type :expr, :by "rJG4IHzWf", :at 1549989134156, :id "0phRVRWsRq"
+                  :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "jiPHrKIWoY"
                   :data {
-                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1549989141050, :text "fn", :id "ZB0_f5Lol8"}
+                   "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "->>", :id "fdlLr7rMmy"}
                    "j" {
-                    :type :expr, :by "rJG4IHzWf", :at 1549989141272, :id "bcuHBAHCu4"
+                    :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "3OUOGqZb2V"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1549989141457, :text "e", :id "weSzgZ75E7"}
-                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1549989141964, :text "d!", :id "6oU92bjXq"}
-                     "r" {:type :leaf, :by "rJG4IHzWf", :at 1549989142595, :text "m!", :id "SWbpN2UtlB"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text ":event", :id "oDGGkOXBz7"}
+                     "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "markup", :id "iGL1fYs8C0"}
                     }
                    }
                    "r" {
-                    :type :expr, :by "rJG4IHzWf", :at 1549989143136, :id "fvovcFW8gw"
+                    :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "CmptR97RZi"
                     :data {
-                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1549989146158, :text "on-action", :id "fvovcFW8gwleaf"}
-                     "b" {:type :leaf, :by "rJG4IHzWf", :at 1551029316786, :text "d!", :id "wWtbh073f"}
-                     "d" {:type :leaf, :by "rJG4IHzWf", :at 1551029325382, :text "action", :id "OEKB1XNE9"}
-                     "f" {:type :leaf, :by "rJG4IHzWf", :at 1551029317740, :text "props", :id "blOJbuFC-w"}
-                     "p" {:type :leaf, :by "rJG4IHzWf", :at 1551589108235, :text "data", :id "hXr0w12R3D"}
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "map", :id "suLTsEbvOw"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "41-dTuVL77"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "fn", :id "vMtYtu_NxK"}
+                       "j" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "9WuUoOzJUf"
+                        :data {
+                         "T" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "8mcE9L5Vl6"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "[]", :id "NsAlamrHSGB"}
+                           "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "name", :id "B_aeAYcSaqp"}
+                           "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "action", :id "ppVb2BxpsA0"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "J-Pu1avarBd"
+                        :data {
+                         "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "[]", :id "wnGQDqqGmiE"}
+                         "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "name", :id "Fp9LZw-LwnC"}
+                         "r" {
+                          :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "vLjLl8r14Mc"
+                          :data {
+                           "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "fn", :id "0Pg4su80sz7"}
+                           "j" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "bBJ13yJRujb"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "e", :id "7GD1zDcMG-y"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "d!", :id "S5yIzKTCvmV"}
+                             "r" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "m!", :id "Qzs6QOk0YMr"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "YAqG4e2_Mvt"
+                            :data {
+                             "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "on-action", :id "CozZdIH0Yfm"}
+                             "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "d!", :id "SCeJQjOkj1o"}
+                             "r" {
+                              :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "xu1uKmwpP35"
+                              :data {
+                               "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "read-token", :id "JsGb3neDTIW"}
+                               "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "action", :id "WNKuPQpXmeT"}
+                               "r" {
+                                :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "sJ-eDopc5cU"
+                                :data {
+                                 "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text ":data", :id "tpFJTeFu-G1"}
+                                 "j" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "context", :id "qdN9NMDEdyJ"}
+                                }
+                               }
+                              }
+                             }
+                             "v" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "props", :id "4OkgZTRGN23"}
+                             "x" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "param", :id "o8_H7jQE-oI"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "Cj9pPV9YZFo"
+                    :data {
+                     "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "into", :id "IijbgTyznBE"}
+                     "j" {
+                      :type :expr, :by "rJG4IHzWf", :at 1552154732500, :id "RTHOGbC2m_x"
+                      :data {
+                       "T" {:type :leaf, :by "rJG4IHzWf", :at 1552154732500, :text "{}", :id "gTq3znB5uhf"}
+                      }
+                     }
                     }
                    }
                   }

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "composer",
-       :version "0.1.0",
+       :version "0.1.1-a1",
        :name "Respo composer renderer library"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "composer",
-       :version "0.1.1-a1",
+       :version "0.1.1-a2",
        :name "Respo composer renderer library"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/respo_composer/core.cljs
+++ b/src/respo_composer/core.cljs
@@ -74,7 +74,7 @@
          scope)
       (string/starts-with? x ":") (keyword (subs x 1))
       (string/starts-with? x "~") (read-string (subs x 1))
-      (string/starts-with? x "") (subs x 1)
+      (string/starts-with? x "|") (subs x 1)
       :else x)
     nil))
 
@@ -114,19 +114,24 @@
 (defn render-button [markup context on-action]
   (let [props (:props markup)
         text (read-token (get props "text") (:data context))
-        param (read-token (get props "param") (:data context))]
+        param (read-token (get props "param") (:data context))
+        event-map (->> (:event markup)
+                       (map
+                        (fn [[name action]]
+                          [name
+                           (fn [e d! m!]
+                             (on-action
+                              d!
+                              (read-token action (:data context))
+                              param
+                              {:event (:event e), :props props, :data (:data context)}))]))
+                       (into {}))]
     (button
      (merge
       (eval-attrs (:attrs markup) (:data context))
       {:style (merge ui/button (style-presets (:presets markup)) (:style markup)),
        :inner-text (or text "Submit"),
-       :on (->> (:event markup)
-                (map
-                 (fn [[name action]]
-                   [name
-                    (fn [e d! m!]
-                      (on-action d! (read-token action (:data context)) props param))]))
-                (into {}))}))))
+       :on event-map}))))
 
 (defn render-divider [markup]
   (let [props (:props markup)
@@ -143,18 +148,23 @@
         size (js/parseFloat (get props "size" "16"))
         color (get props "color" (hsl 200 80 70))
         obj (aget (.-icons icons) icon-name)
-        param (read-token (get props "param") (:data context))]
+        param (read-token (get props "param") (:data context))
+        event-map (->> (:event markup)
+                       (map
+                        (fn [[name action]]
+                          [name
+                           (fn [e d! m!]
+                             (on-action
+                              d!
+                              (read-token action (:data context))
+                              param
+                              {:event (:event e), :props props, :data (:data context)}))]))
+                       (into {}))]
     (if (some? obj)
       (i
        {:style {:display :inline-block, :cursor :pointer},
         :innerHTML (.toSvg obj (clj->js {:width size, :height size, :color color})),
-        :on (->> (:event markup)
-                 (map
-                  (fn [[name action]]
-                    [name
-                     (fn [e d! m!]
-                       (on-action d! (read-token action (:data context)) props param))]))
-                 (into {}))})
+        :on event-map})
       (comp-invalid (str "No icon: " icon-name) props))))
 
 (defn render-input [markup context on-action]
@@ -170,11 +180,12 @@
                            (fn [e d! m!]
                              (on-action
                               d!
-                              (read-token
-                               action
-                               {:text (:value e), :event (:event e), :data context})
-                              props
-                              param))]))
+                              (read-token action (:data context))
+                              param
+                              {:props props,
+                               :value (:value e),
+                               :event (:event e),
+                               :data (:data context)}))]))
                        (into {}))]
     (if textarea?
       (textarea
@@ -208,20 +219,25 @@
   (let [props (:props markup)
         text (read-token (get props "text") (:data context))
         href (read-token (get props "href") (:data context))
-        param (read-token (get props "param") (:data context))]
+        param (read-token (get props "param") (:data context))
+        event-map (->> (:event markup)
+                       (map
+                        (fn [[name action]]
+                          [name
+                           (fn [e d! m!]
+                             (on-action
+                              d!
+                              (read-token action (:data context))
+                              param
+                              {:event (:event e), :props props, :data (:data context)}))]))
+                       (into {}))]
     (a
      (merge
       (eval-attrs (:attrs markup) (:data context))
       {:style (merge ui/link (:style markup)),
        :inner-text (or text "Submit"),
        :href (or href "#"),
-       :on (->> (:event markup)
-                (map
-                 (fn [[name action]]
-                   [name
-                    (fn [e d! m!]
-                      (on-action d! (read-token action (:data context)) props param))]))
-                (into {}))}))))
+       :on event-map}))))
 
 (defn render-slot [markup context on-action]
   (let [props (:props markup), dom (or (get props "dom") (:dom props))]
@@ -354,7 +370,18 @@
   (let [props (:props markup)
         value (read-token (get props "name") (:data context))
         tag-name (keyword (or value "div"))
-        param (read-token (get props "param") (:data context))]
+        param (read-token (get props "param") (:data context))
+        event-map (->> (:event markup)
+                       (map
+                        (fn [[name action]]
+                          [name
+                           (fn [e d! m!]
+                             (on-action
+                              d!
+                              (read-token action (:data context))
+                              param
+                              {:event (:event e), :props props, :data (:data context)}))]))
+                       (into {}))]
     (create-list-element
      tag-name
      (merge
@@ -363,13 +390,7 @@
                (get-layout (:layout markup))
                (style-presets (:presets markup))
                (:style markup)),
-       :on (->> (:event markup)
-                (map
-                 (fn [[name action]]
-                   [name
-                    (fn [e d! m!]
-                      (on-action d! (read-token action (:data context)) props param))]))
-                (into {}))})
+       :on event-map})
      (render-children (:children markup) context on-action))))
 
 (defn render-children [children context on-action]
@@ -378,7 +399,19 @@
        (map (fn [[k child]] [k (render-markup child context on-action)]))))
 
 (defn render-box [markup context on-action]
-  (let [props (:props markup), param (read-token (get props "data") (:data context))]
+  (let [props (:props markup)
+        param (read-token (get props "param") (:data context))
+        event-map (->> (:event markup)
+                       (map
+                        (fn [[name action]]
+                          [name
+                           (fn [e d! m!]
+                             (on-action
+                              d!
+                              (read-token action (:data context))
+                              param
+                              {:event (:event e), :props props, :data (:data context)}))]))
+                       (into {}))]
     (list->
      (merge
       (eval-attrs (:attrs markup) (:data context))
@@ -386,11 +419,5 @@
                (get-layout (:layout markup))
                (style-presets (:presets markup))
                (:style markup)),
-       :on (->> (:event markup)
-                (map
-                 (fn [[name action]]
-                   [name
-                    (fn [e d! m!]
-                      (on-action d! (read-token action (:data context)) props param))]))
-                (into {}))})
+       :on event-map})
      (render-children (:children markup) context on-action))))


### PR DESCRIPTION
Events are now described in a map in `:event` so multiple events are supported, which is used in https://github.com/Erigeron/composer-todolist/pull/5 .