### PR TITLE
Several changes to make mocking easier

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -9437,6 +9437,27 @@
                                  "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592169707, :text "\"0 8px", :id "YRni6Z7ThB"}
                                 }
                                }
+                               "v" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1553103612595, :id "w-NxlJpHL"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103614691, :text ":border-bottom", :id "w-NxlJpHLleaf"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103621876, :text "\"1px solid #eee", :id "wy1NWBM745"}
+                                }
+                               }
+                               "x" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1553103637905, :id "_jWBJzBFG"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103643499, :text ":line-height", :id "_jWBJzBFGleaf"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103661866, :text "\"32px", :id "F-JIn4foS"}
+                                }
+                               }
+                               "y" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1553103637905, :id "xT8SySOZob"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103657684, :text ":height", :id "_jWBJzBFGleaf"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103663568, :text "\"32px", :id "F-JIn4foS"}
+                                }
+                               }
                               }
                              }
                              "j" {
@@ -9537,10 +9558,17 @@
                         :data {
                          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548576351986, :text "<>", :id "jxCPr8GOqleaf"}
                          "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548576352373, :id "7MV2vvspej"
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553103670027, :id "-xf39PtKvR"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548576356629, :text ":name", :id "x_gkFanOBJ"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548576357033, :text "mock", :id "UF1rS39IHQ"}
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103672232, :text "or", :id "gPb_2WD34"}
+                           "T" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1548576352373, :id "7MV2vvspej"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548576356629, :text ":name", :id "x_gkFanOBJ"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548576357033, :text "mock", :id "UF1rS39IHQ"}
+                            }
+                           }
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103678305, :text "\"-", :id "TgxESBF2v"}
                           }
                          }
                         }
@@ -9969,7 +9997,7 @@
                 :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "eSK88KNT7S"
                 :data {
                  "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":inner-text", :id "AAduAPo5Do"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "\"Use this", :id "bmtrpqaKM5"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103325552, :text "\"Use it", :id "bmtrpqaKM5"}
                 }
                }
                "v" {
@@ -10031,6 +10059,135 @@
            }
            "w" {
             :type :expr, :by "B1y7Rc-Zz", :at 1551551187883, :id "JqSnSJVLXs"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "=<", :id "pNPsJk9J_v"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "8", :id "dL33qX_uDz"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "nil", :id "ybnq2N3XhC"}
+            }
+           }
+           "wD" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553103336767, :id "1lIQxpOXg"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103338346, :text "cursor->", :id "1lIQxpOXgleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103348510, :text ":fork", :id "7QgIetmZC"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103353373, :text "comp-prompt", :id "1wKe67T2B"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103354696, :text "states", :id "6V8DyXE05"}
+             "x" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103355355, :id "cyoylQCsMc"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103355715, :text "{}", :id "lqidQl66zJ"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103356838, :id "XPRBtEQsy"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103358114, :text ":trigger", :id "9fohxv5hYJ"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "Bm-T9EHluK"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "a", :id "IM2_ntColL"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "DDhHEQttHp"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "{}", :id "N69IDjk7qY"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "ICnrV9_dEu"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text ":style", :id "i6kq_BqIca"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "ui/link", :id "3laiNwgT85"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "k5hDjJbrfE"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text ":inner-text", :id "NNFB1nx-wd"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103364126, :text "\"Fork", :id "pH-BTTPafz"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103368066, :id "UZSqcUHQon"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103369671, :text ":text", :id "UZSqcUHQonleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103378877, :text "\"Fork with new name:", :id "xLFQo-Jl3m"}
+                }
+               }
+              }
+             }
+             "y" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103381557, :id "xZ4EGrzup"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103382609, :text "fn", :id "xZ4EGrzupleaf"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103383021, :id "BHLmVT8keO"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103388305, :text "result", :id "S25wSeIs0J"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103384199, :text "d!", :id "-kylNYIUx"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103385698, :text "m!", :id "hG-RvPuND"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103388827, :id "Ycdxav4iAB"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103391757, :text "when-not", :id "Ycdxav4iABleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103392090, :id "c9jSfGu3h9"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103397954, :text "string/blank?", :id "rLWTiFc5ah"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103400560, :text "result", :id "5LktjMRXE"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103401543, :id "Q7_UxRbZA"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103404178, :text "d!", :id "Q7_UxRbZAleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103411123, :text ":template/fork-mock", :id "SG1BK0SZRV"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103411938, :id "pW_CfaQj8q"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103412317, :text "{}", :id "SEdOu9GhK"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103412606, :id "6O8SZ2RyP"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103420194, :text ":template-id", :id "C1sKfmm0Mb"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103415767, :text "template-id", :id "kTwGzrk1cX"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103421049, :id "J9EhOUl9hV"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103424816, :text ":mock-id", :id "J9EhOUl9hVleaf"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103428710, :id "cMVlJVt5r"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103426015, :text ":id", :id "ZRl6NKLr7v"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103431538, :text "mock", :id "Hxh7qtcAqy"}
+                        }
+                       }
+                      }
+                     }
+                     "v" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103434373, :id "XC6gZLGcK7"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103438850, :text ":name", :id "XC6gZLGcK7leaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103441684, :text "result", :id "Znw14MPIK"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "wT" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551551187883, :id "_PivaZw-0"
             :data {
              "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "=<", :id "pNPsJk9J_v"}
              "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "8", :id "dL33qX_uDz"}
@@ -30804,6 +30961,13 @@
                  "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594244250, :text "template/rename-mock", :id "Zlo4zrgIAL"}
                 }
                }
+               "yuxT" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103086670, :id "30v1Kt6pQ"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103094525, :text ":template/fork-mock", :id "30v1Kt6pQleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103127166, :text "template/fork-mock", :id "vDYdTuBuPJ"}
+                }
+               }
                "yuy" {
                 :type :expr, :by "B1y7Rc-Zz", :at 1548570432368, :id "xQtiuYxlX"
                 :data {
@@ -33546,6 +33710,177 @@
             }
            }
            "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570519606, :text "new-template", :id "uUbuKXAHEZ"}
+          }
+         }
+        }
+       }
+      }
+     }
+     "fork-mock" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1553103102533, :id "M24mdrtIHs"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103102533, :text "defn", :id "r6etiKHm4p"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103102533, :text "fork-mock", :id "A9rDzOaquS"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "T1cnA73XKL"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "db", :id "xiryxTfKJm"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "op-data", :id "ZUrnNK8DIs"}
+         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "sid", :id "dMn_Y9MsdE"}
+         "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "op-id", :id "hWImVHn-Vg"}
+         "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "op-time", :id "yQ-w1vn1LB"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "NjxWs_auba"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "let", :id "jy_2zDukOj"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "lZIzIeWWT2"
+          :data {
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "Cp9tHB5bjj"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "template-id", :id "CP9RlgZIcQm"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "Pwf8xHqBPYG"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text ":template-id", :id "GNudBxtxzub"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "op-data", :id "Os0aBZxanO1"}
+              }
+             }
+            }
+           }
+           "b" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553103150496, :id "NpypSVFo7t"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103153260, :text "mock-id", :id "NpypSVFo7tleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103160735, :id "BTFelQKBM"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103163937, :text ":mock-id", :id "CJrf3wm4s"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103165469, :text "op-data", :id "rcTfFIiaDt"}
+              }
+             }
+            }
+           }
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "RBDdv0BuZVb"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103172605, :text "new-name", :id "1D_RE5PQKoX"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "UqsuaUA7rVu"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103553889, :text ":name", :id "dJnVcFAB3Cm"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "op-data", :id "BsaqJi3VDse"}
+              }
+             }
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "xruuEGFfN_X"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103192767, :text "update-in", :id "cSuEbRC5dNa"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "db", :id "qp_SEi_ExiD"}
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553103116491, :id "JxQlkl6mjlw"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "[]", :id "ez-mFyHwtDa"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text ":templates", :id "WlwCEUnTxjP"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text "template-id", :id "ujMs4y7uFY3"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103116491, :text ":mocks", :id "bjzlZ6TSRCz"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553103197908, :id "lzdcHxaL5"
+            :data {
+             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103198612, :text "fn", :id "O9dxKsNzkM"}
+             "L" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103199254, :id "1yIYZ8tw1i"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103199881, :text "mocks", :id "txcQKhTxZt"}
+              }
+             }
+             "P" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103200738, :id "eW9zqqOK-"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103202760, :text "let", :id "eW9zqqOK-leaf"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103203050, :id "hoc7DyH__9"
+                :data {
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103203167, :id "xUXsEol4yr"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103204339, :text "old-mock", :id "f1PUXM0CDz"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103205306, :id "9yf2xqpDzJ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103206424, :text "get", :id "9iCjEQP8o"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103207590, :text "mocks", :id "oFInj_xhj"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103209616, :text "mock-id", :id "kuzmDfI1wi"}
+                    }
+                   }
+                  }
+                 }
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103216838, :id "eI5PWQj-Wr"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103216838, :text "new-mock", :id "8WKqAdIMtm"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103216838, :id "-WT0YjM0xb"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103216838, :text "merge", :id "_ono4IqAa7"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103219918, :text "old-mock", :id "S4_MPlw4P4"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103216838, :id "bV3FDVVefV"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103216838, :text "{}", :id "l2apf0iCe_"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103216838, :id "sMOl1Fa1pJ"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103216838, :text ":id", :id "bcdQYfJ41a"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103216838, :text "op-id", :id "i7o_V_qgl5"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103216838, :id "_NvOaPNAM0"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103216838, :text ":name", :id "hDGCzo8iri"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103224044, :text "new-name", :id "7g-0gEweCl"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "n" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103523225, :id "XNz2irl7AR"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103523225, :text "println", :id "Enoy4z84zj"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103523225, :text "\"mocks", :id "5Xf7ayBpR3"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103523225, :text "mocks", :id "yH0oZ37fVv"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103527463, :text "new-mock", :id "vpvHLSUgE2"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103227842, :id "slCExmUeo"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103228739, :text "assoc", :id "slCExmUeoleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103230251, :text "mocks", :id "0-Dw6TlLEr"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103236548, :text "op-id", :id "m9GJFMvHM"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103238108, :text "new-mock", :id "eUWOi5PnjV"}
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
         }

--- a/calcit.edn
+++ b/calcit.edn
@@ -22457,7 +22457,7 @@
                   :data {
                    "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "or", :id "OQYx7YfWtzhv"}
                    "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "text", :id "VfmDOl3QaEub"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"Submit", :id "iEWROcemT-EY"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101888406, :text "\"Submit", :id "iEWROcemT-EY"}
                   }
                  }
                 }
@@ -26583,84 +26583,102 @@
           }
          }
          "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "FT6szaWXLYX"
+          :type :expr, :by "B1y7Rc-Zz", :at 1553101751664, :id "0qt78WKYb5"
           :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "if", :id "K54vUPbmnjx"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "5MCwyiNvK6G"
+           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101752908, :text "cond", :id "JJTIVtshKv"}
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "FT6szaWXLYX"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "not=", :id "XXF7syPSv5_"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "-rORiUlYHUO"
+              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "5MCwyiNvK6G"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "count", :id "7hwQh52mHs5"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "child-pair", :id "htLtS2dt21X"}
-              }
-             }
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "2", :id "RhpbrA3c3i-"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "oOIFHYIfThK"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "do", :id "N-XXeQ5nlD9"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "KmxtdN0tuDA"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "js/console.warn", :id "RVAeo1bvcRk"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"<Some> requires 2 children, but got", :id "hTqV6J7sxit"}
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "o1zmDtGTBet"
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "not=", :id "XXF7syPSv5_"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "-rORiUlYHUO"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "count", :id "j5EuV1BC-Pq"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "child-pair", :id "d2s0_ke9AQv"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "count", :id "7hwQh52mHs5"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "child-pair", :id "htLtS2dt21X"}
                 }
                }
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "2", :id "RhpbrA3c3i-"}
               }
              }
              "r" {
               :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "LzMIE639Rrv"
               :data {
                "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "comp-invalid", :id "SyioUg3xXtW"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"<Bad some>", :id "Bar9DXUcNXn"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101718181, :text "\"<Some wants 2 children>", :id "Bar9DXUcNXn"}
                "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "props", :id "z0X8vIWqCGN"}
               }
              }
             }
            }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "zwoEfeXCczE"
+           "b" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553101766422, :id "OHSRiFKLUJ"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "if", :id "7BQmY7sCLr6"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "result", :id "8yWLYvJ0kpW"}
-             "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "P_jrWb3T3rQ"
+             "T" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553101798055, :id "7kiDV4FVU"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "render-markup", :id "JPicKVqO5_r"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101799867, :text "nil?", :id "OHSRiFKLUJleaf"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "1CYKP3YOKcd"
+                :type :expr, :by "B1y7Rc-Zz", :at 1553101802691, :id "eUUSuv29D"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "first", :id "mHUzPmbxmpI"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "child-pair", :id "_PiBOvAqvl0"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101801095, :text "get", :id "Og76jDwX3F"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101803672, :text "props", :id "wphnS11kd3"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101804773, :text "\"value", :id "5kVvoK7s8s"}
                 }
                }
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "context", :id "3Eedrx8gmBT"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "on-action", :id "OiM9gJAb7mY"}
               }
              }
-             "v" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nuGEwZpG4Wy"
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553101805782, :id "_M4yLczfC"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "render-markup", :id "3VWxs5ktY2w"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "9_hf6qJcrOu"
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101807661, :text "comp-invalid", :id "_M4yLczfCleaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101817248, :text "\"<Some requires a value>", :id "0Ti_QHd-JG"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101822938, :text "props", :id "tyTnbCSoYi"}
+              }
+             }
+            }
+           }
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553101759403, :id "Z1pa6R3bx"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101761197, :text ":else", :id "7jgkZjwcH1"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553101762145, :id "0Hw8kl435v"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "if", :id "uebF1VWox4"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "result", :id "Dxv0k58AOG"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553101762145, :id "tPv0699GSR"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "last", :id "voV8TXiizym"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "child-pair", :id "nL-_Yyv-5Ac"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "render-markup", :id "agN35WlIvL"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553101762145, :id "sAxfwRK4_p"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "first", :id "Sz7U2P95jn"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "child-pair", :id "VkV9oz_9RV"}
+                  }
+                 }
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "context", :id "O5qJWSN18-"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "on-action", :id "SZnaDW_zsd"}
                 }
                }
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "context", :id "4I5rwfP5bbZ"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "on-action", :id "vEC_8sgY9Ra"}
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553101762145, :id "4_LDGfGIUv"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "render-markup", :id "o1MPhE5-WA"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553101762145, :id "NCuY-G7MrY"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "last", :id "2Yjims8iR8"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "child-pair", :id "20lBXqiyEx9"}
+                  }
+                 }
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "context", :id "nup-8hIAnx7"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101762145, :text "on-action", :id "t8u97NmIz1P"}
+                }
+               }
               }
              }
             }
@@ -26760,11 +26778,45 @@
           }
          }
          "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "moJTKTa6L-xH"
+          :type :expr, :by "B1y7Rc-Zz", :at 1553101565283, :id "iS06Y1CPKA"
           :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "=<", :id "TAORNddW4Nyc"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "width", :id "6n7znvwgAMza"}
-           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "height", :id "1h804fYWUhcw"}
+           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101566556, :text "if", :id "VpS-GfoaV"}
+           "L" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553101566855, :id "2Qv-7OEqOP"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101569900, :text "and", :id "hLrC6NWHSW"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553101572122, :id "Ijzn7Pai-h"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101572973, :text "nil?", :id "AGKPi5yy_"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101574223, :text "width", :id "BruOv0Ciqv"}
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553101575196, :id "jg3ePvycQ3"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101576485, :text "nil?", :id "jg3ePvycQ3leaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101577913, :text "height", :id "PSnz4dj4V"}
+              }
+             }
+            }
+           }
+           "P" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553101578874, :id "SpIovOj96E"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101581300, :text "comp-invalid", :id "SpIovOj96Eleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101587780, :text "\"<Space nil>", :id "RFKROV1MC"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101591457, :text "props", :id "JI9zjdp5og"}
+            }
+           }
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "moJTKTa6L-xH"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "=<", :id "TAORNddW4Nyc"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "width", :id "6n7znvwgAMza"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "height", :id "1h804fYWUhcw"}
+            }
+           }
           }
          }
         }
@@ -27051,7 +27103,14 @@
           :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nG1LvhTC4Jfv"
           :data {
            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "<>", :id "xoEqP2Y_uUwa"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "value", :id "Cv1UuQ0-FaL0"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553101441334, :id "wpEJk_POuU"
+            :data {
+             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101442503, :text "or", :id "NvaO3Jz7-"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "value", :id "Cv1UuQ0-FaL0"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553101644474, :text "\"TEXT", :id "n5EBahZJO-"}
+            }
+           }
            "r" {
             :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "qViIaJ2rCGji"
             :data {

--- a/calcit.edn
+++ b/calcit.edn
@@ -1785,6 +1785,13 @@
                                              "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552791018048, :text ":pointer", :id "2cs9_r7nBG"}
                                             }
                                            }
+                                           "yT" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1553102038989, :id "7976qcaXOQ"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102041000, :text ":border", :id "7976qcaXOQleaf"}
+                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102052431, :text "\"1px solid #ddd", :id "YwHS6rHVIJ"}
+                                            }
+                                           }
                                           }
                                          }
                                         }
@@ -10825,11 +10832,11 @@
             :type :expr, :by "B1y7Rc-Zz", :at 1551550343462, :id "81YVPw3HJ0"
             :data {
              "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551550348152, :text "comp-entry", :id "81YVPw3HJ0leaf"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551550406031, :id "2-JlD6ogb"
+             "d" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553102750132, :id "gZ7lnpwf-"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551550407784, :text ":title", :id "oMC9ZG6SG"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551550409267, :text "config/site", :id "DTyCTRdjdU"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102766186, :text ":title", :id "FxUtxxe9Ww"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102756646, :text "config/site", :id "-U-EuCDo4"}
               }
              }
              "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1551550414076, :text ":home", :id "Qq0GEDk3j"}
@@ -20759,7 +20766,7 @@
           :type :expr, :by "root", :at 1527867502467, :id "BkeUud1ye7"
           :data {
            "T" {:type :leaf, :by "root", :at 1527867504737, :text ":title", :id "BkeUud1ye7leaf"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549556342059, :text "\"Composer App", :id "H1zKduykx7"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102763203, :text "\"Composer", :id "H1zKduykx7"}
           }
          }
          "u" {
@@ -26521,11 +26528,24 @@
                 :data {
                  "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":boolean", :id "3tX7NNMl_xg"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "wOMFbixzT50"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553102506533, :id "tJgGp477t"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "=", :id "FV1J1r-qHcu"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "value", :id "LXKcf5XyOD_"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "false", :id "Y1T2LAhin7o"}
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102509611, :text "or", :id "tMgUVBonDp"}
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "wOMFbixzT50"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "=", :id "FV1J1r-qHcu"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "value", :id "LXKcf5XyOD_"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "false", :id "Y1T2LAhin7o"}
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553102510188, :id "4LFPY0PmTJ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102514244, :text "nil?", :id "4LFPY0PmTJleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102515576, :text "value", :id "VSbIghgoLI"}
+                    }
+                   }
                   }
                  }
                 }
@@ -33352,6 +33372,13 @@
              "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548609877132, :text "\"system", :id "gELcowQFvm"}
             }
            }
+           "9" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553102901326, :id "VJpvSgVxte"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102903007, :text "mock-id", :id "VJpvSgVxteleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102905996, :text "\"base", :id "YhIH5YTA3R"}
+            }
+           }
            "D" {
             :type :expr, :by "B1y7Rc-Zz", :at 1548570397467, :id "AE_LyVQcfL"
             :data {
@@ -33392,6 +33419,51 @@
              }
             }
            }
+           "L" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553102829013, :id "i2aiSpCac"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102833334, :text "new-mock", :id "i2aiSpCacleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553102834631, :id "Je6S_ikON"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102841701, :text "merge", :id "cYw_qrSQb"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102845595, :text "schema/mock", :id "Yown5UNqGi"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553102850269, :id "_Z5vt3-JAX"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102851541, :text "{}", :id "ay2JB2CFU"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553102851939, :id "TMzVQsyaYS"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102854603, :text ":id", :id "rJ1zJY4J4k"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102913817, :text "mock-id", :id "xra5WyGLtW"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553102866303, :id "dMN6NwKUSd"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102867086, :text ":name", :id "dMN6NwKUSdleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102876754, :text "\"base", :id "nHTw9mCna"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553102872259, :id "OSajbwaPBp"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102873019, :text ":data", :id "OSajbwaPBpleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553102873684, :id "GC8ENv2SY"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102874025, :text "{}", :id "5l6oyOEqUC"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
            "T" {
             :type :expr, :by "B1y7Rc-Zz", :at 1548570246459, :id "g6fJfIpx4F"
             :data {
@@ -33424,6 +33496,32 @@
                   :data {
                    "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570310109, :text ":markup", :id "j6fewrUBydleaf"}
                    "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570395756, :text "base-markup", :id "Zqv32u4Y5f"}
+                  }
+                 }
+                 "x" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553102884868, :id "ZVqnkKWA3S"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102887858, :text ":mocks", :id "ZVqnkKWA3Sleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553102888537, :id "CfI8BgYRu"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102890327, :text "{}", :id "R1cU5SwGkM"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553102890628, :id "PhUlUVY7I"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102916136, :text "mock-id", :id "AyXBnkBXGM"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102918786, :text "new-mock", :id "pKHX1bp4N3"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "y" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553102946299, :id "VpW4O3pcgA"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102946299, :text ":mock-pointer", :id "t_XdV-lnj2"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102989367, :text "mock-id", :id "6QkM11Qxc_"}
                   }
                  }
                 }

--- a/calcit.edn
+++ b/calcit.edn
@@ -9067,11 +9067,475 @@
           }
          }
         }
+        "yyr" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1553105236286, :id "rI2MoZFcH_"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105236720, :text "[]", :id "rI2MoZFcH_leaf"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105242642, :text "inflow-popup.comp.popup", :id "kh4Kgw2mtG"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105243528, :text ":refer", :id "p4JBCWSjjp"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1553105243699, :id "xYEl-hc4f5"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105243918, :text "[]", :id "9NZauCEcao"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105247394, :text "comp-popup", :id "zY7qyqONbe"}
+           }
+          }
+         }
+        }
        }
       }
      }
     }
     :defs {
+     "comp-data-editor" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1553105457203, :id "0cy4qLxvHw"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105458868, :text "defcomp", :id "U2VQnpwti4"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105457203, :text "comp-data-editor", :id "nYmG0Kmo1v"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1553105457203, :id "EFb9TLWPV5"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105460793, :text "states", :id "2vNxbwtbQJ"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105462260, :text "data", :id "dKIpIUrQ4s"}
+         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105528855, :text "on-submit", :id "fZpEUlJeCV"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1553105584121, :id "wqWPo8R17"
+        :data {
+         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105584938, :text "let", :id "7cFEfhtmLo"}
+         "L" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553105585176, :id "WsYbPmA6k1"
+          :data {
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553105585340, :id "Mj4FSJUDRZ"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105586031, :text "state", :id "Fp8oHcRIfZ"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105595374, :id "ZrrdgSgrX"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105597227, :text "or", :id "fGiXp2cPnD"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105597955, :id "-ScGCDMlJG"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105598535, :text ":data", :id "QVGKplzCYz"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105599436, :text "states", :id "FFoGBFGzaP"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105600653, :id "u3yMsAE8Z"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105601061, :text "{}", :id "u3yMsAE8Zleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105601474, :id "ZQ_vn13vv-"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105603269, :text ":draft", :id "J2EdmOY0eH"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105603771, :id "9V-Vggsfpf"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105603771, :text "write-edn", :id "hj7RYp38R1"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105614624, :text "data", :id "B7RpATpIT_"}
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105942797, :id "0sjxFIroLV"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105943725, :text ":error", :id "0sjxFIroLVleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105945275, :text "nil", :id "xD4U1DbXyL"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+         "T" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553105463930, :id "N_DaB984g"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105469637, :text "div", :id "N_DaB984gleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553105471919, :id "b5NBFppHV6"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105472339, :text "{}", :id "8SrIFxIJh"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105474124, :id "ld86mojkX7"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105476368, :text ":style", :id "IBJ99He9p"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105478738, :text "ui/column", :id "5pq1ydaVe1"}
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553105479650, :id "fQuNJktUY"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105481728, :text "textarea", :id "fQuNJktUYleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105482018, :id "8rB3t8JTJK"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105482351, :text "{}", :id "5ANQdo3Umw"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105482570, :id "5MZzy87Y3"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105483307, :text ":style", :id "IADo1ExrAA"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105550645, :id "HqKhv_cXJ"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105552140, :text "merge", :id "LebjU5FcMJ"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105485795, :text "ui/textarea", :id "g5B9Zgu_gU"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text "style-code", :id "nYer6xVMVz3"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106215896, :id "SXGXAcsrQ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106218053, :text "{}", :id "gq7gabATFp"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553106219374, :id "jeCoEtaNDd"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106219374, :text ":height", :id "UUz1Eq_MaQ"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106219374, :text "240", :id "JSlPWG3Nvv"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553106385901, :id "9q0TKB2MsZ"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106385901, :text ":width", :id "nV1O5NwSoi"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106393468, :text "600", :id "2wob2mtVdK"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105607774, :id "Wvqh0hRUBW"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105616561, :text ":placeholder", :id "Wvqh0hRUBWleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105620110, :text "\"EDN data", :id "boA77eOUHD"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105634541, :id "rhgW3ypJB"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105635319, :text ":value", :id "rhgW3ypJBleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105636664, :id "fiEep16Xr"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105637654, :text ":draft", :id "j7sCiyEdAo"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105638708, :text "state", :id "9f8cCF5kTz"}
+                  }
+                 }
+                }
+               }
+               "x" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105640358, :id "4AJ0Xcavdk"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105647425, :text ":on-input", :id "4AJ0Xcavdkleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105641928, :id "x7ahypvyTM"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105642191, :text "fn", :id "gnhFurwrkn"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105642442, :id "YOMgZyyzdd"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105642637, :text "e", :id "KhcLF4-Jgo"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105643283, :text "d!", :id "CyzTwqmB2G"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105643932, :text "m!", :id "w58uODtB_w"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105649629, :id "1p3U5JO1x"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105650478, :text "m!", :id "1p3U5JO1xleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105652220, :id "yCf-oCrO6Z"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105653483, :text "assoc", :id "_gKw5pitML"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105655455, :text "state", :id "YVRL7xIXR"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105658078, :text ":draft", :id "rhxABM-nm"}
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553105658679, :id "9V3yQKrVd"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105660212, :text ":value", :id "XNg2uFJFcg"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105661569, :text "e", :id "bLhl0odwqa"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553105487775, :id "bsjqJiQni"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105489769, :text "div", :id "bsjqJiQnileaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105490013, :id "o1fiVAR5lc"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105490353, :text "{}", :id "mh0piWw-AX"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105490646, :id "VpRUd2oVF"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105491762, :text ":style", :id "Rx26WX24w9"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105492327, :id "a0kizMTE7e"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105492995, :text "merge", :id "nCn1kyPt0y"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105497756, :text "ui/row-parted", :id "FonoSXJCan"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105536603, :id "bw2nlljtx"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105537054, :text "{}", :id "IEuZBKFMef"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105538342, :id "EZigSHIs_l"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105545381, :text ":margin-top", :id "LAwmOvdnrG"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105546524, :text "8", :id "g4MvADKIL"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105953813, :id "XPfXgrfinX"
+              :data {
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105954720, :text "if", :id "xPdi_oiL7G"}
+               "L" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105956583, :id "pPKboGQC2"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105958370, :text "some?", :id "aqz8-ov1hQ"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105959387, :id "NxtBgROHpk"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105960288, :text ":error", :id "I88O1wRA3"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105962450, :text "state", :id "xPPJFH8JX"}
+                  }
+                 }
+                }
+               }
+               "P" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553106012608, :id "Wz7KVg5dQ"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106014226, :text "div", :id "mXmI999eZY"}
+                 "L" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553106014498, :id "SsSOLfcuFP"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106014842, :text "{}", :id "uJntSaP9I2"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106019262, :id "PR73NZig3p"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106020785, :text ":style", :id "VyoqelrxK"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553106021041, :id "wP_QzIJ1L9"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106021329, :text "{}", :id "Yk2AlG-xNr"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106021605, :id "KXzcf8SeK"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106022395, :text ":color", :id "k54oz8dgvO"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106022982, :text ":red", :id "8lD_G3wFom"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106023576, :id "-YtUSeRlf"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106025707, :text ":max-width", :id "-YtUSeRlfleaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106027905, :text "360", :id "-GHd7E7Txi"}
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106033883, :id "s_z8fYhBzD"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106036610, :text ":line-height", :id "s_z8fYhBzDleaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106042705, :text "\"20px", :id "i37u_qjdS_"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105964169, :id "PwBk7ySebV"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105965991, :text "<>", :id "PwBk7ySebVleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105967417, :id "glBMaaWP_9"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105969182, :text ":error", :id "2qOtj8t60"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105970036, :text "state", :id "163iGNMPyA"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105970645, :id "ZQfhhOcTa"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105971108, :text "{}", :id "ZQfhhOcTaleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105974049, :id "-AdS9XULp"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105974769, :text ":color", :id "Ey5mq-Zqs"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105975366, :text ":red", :id "9gZy0De6jg"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105499100, :id "d2rO4ih0qd"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105952866, :text "span", :id "d2rO4ih0qdleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105501234, :text "nil", :id "aWovyJSTNd"}
+                }
+               }
+              }
+             }
+             "v" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105501714, :id "9yGZpmR4lu"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105504671, :text "button", :id "9yGZpmR4luleaf"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105504947, :id "sn0_aeRAqZ"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105505315, :text "{}", :id "A74qhZr18r"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105507461, :id "IfmTIlnWWe"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105510166, :text ":inner-text", :id "pbXYBgVUxO"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105512111, :text "\"Submit", :id "idE6FAwFM7"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105514899, :id "lQRdBNOqF"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105515795, :text ":style", :id "lQRdBNOqFleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105517509, :text "ui/button", :id "7VMT6Ccy8i"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105745856, :id "peuqgXS0Dm"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105750263, :text ":on-click", :id "peuqgXS0Dmleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105750992, :id "lGRCiWygvt"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105752289, :text "fn", :id "XLe_oUBavi"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105752575, :id "wX89FAzM-"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105752916, :text "e", :id "cUq5PuZExg"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105753502, :text "d!", :id "FILsdcZWVq"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105754634, :text "m!", :id "6ucsEXlxI"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105755810, :id "j2Ca75mG8A"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "try", :id "fwKm8cjy9d"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553105755810, :id "AIKldDlWqQ"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "do", :id "1Ao0Wn1pCa"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553105760428, :id "L9S7cb0ris"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105766451, :text "on-submit", :id "L9S7cb0risleaf"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553105789511, :id "V7ChBlKHze"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105789511, :text "read-string", :id "v-AMnApIJA"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1553105789511, :id "NkCUN6aoz6"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105789511, :text ":draft", :id "zvmVSTWHYG"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105789511, :text "state", :id "uz83Uwej0c"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105810678, :text "d!", :id "NbNOGGU5mi"}
+                           "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105873975, :text "m!", :id "rox6BqUU0Y"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553105793189, :id "6v5q5OgEgd"
+                          :data {
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105794585, :text "m!", :id "TKDGz_sN3"}
+                           "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105797644, :text "nil", :id "8dQ88Ktu8_"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553105755810, :id "Uvwepzt5uBa"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "catch", :id "Te9E7GW2KLu"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "js/Error", :id "1r80efnEEIm"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "err", :id "ZPiUCgr9yek"}
+                         "v" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553105755810, :id "KRKRjTybyKl"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text ".error", :id "O8r79sjS5jo"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "js/console", :id "4hduYlCJBKP"}
+                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105755810, :text "err", :id "z6hnhnQ1ScJ"}
+                          }
+                         }
+                         "x" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553105984424, :id "dup3H8-9V8"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105988222, :text "m!", :id "dup3H8-9V8leaf"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553105989100, :id "17uOfpdly"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105990646, :text "assoc", :id "msh4gWt1_v"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105991370, :text "state", :id "7W073UGVsx"}
+                             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105992333, :text ":error", :id "kye2RxSCuo"}
+                             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105998771, :text "err", :id "28ul5ZEvp"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
      "comp-mock-data" {
       :type :expr, :id "HJHJG58xgASW", :by nil, :at 1500541010211
       :data {
@@ -9763,50 +10227,36 @@
         }
        }
        "r" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1548592405659, :id "D_ZdR7KZ95"
+        :type :expr, :by "B1y7Rc-Zz", :at 1553105343834, :id "5wsjRl-a0"
         :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592460217, :text "div", :id "yLxyafjVwa"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548592405659, :id "7-tFtHCoEl"
+         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105345853, :text "let", :id "TrxahcrDnD"}
+         "L" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553105346107, :id "sZawSTxYUq"
           :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592405659, :text "{}", :id "IseHGe7-2U"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548592461724, :id "2aDpMGCCx6"
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553105346255, :id "y65y4gQS2G"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592462459, :text ":style", :id "QZgbP1qhZ"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105351213, :text "base-op-data", :id "Z8eFyf9lmC"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548592487482, :id "eD1gA4Qqjm"
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105355801, :id "RRNPVj4B84"
               :data {
-               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592490195, :text "merge", :id "5KhNk55S1"}
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592464447, :text "ui/flex", :id "l8RO2gfO5"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592495458, :text "ui/column", :id "0z_N04NCjV"}
-              }
-             }
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548592473589, :id "8L23dUFib"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592474808, :text "div", :id "8L23dUFibleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548592475079, :id "O0aTWOaGHa"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592475394, :text "{}", :id "vc_AVZMDgQ"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548592560542, :id "W7K7pZM0C"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592562145, :text ":style", :id "GJTeDUU0eo"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105355801, :text "{}", :id "Oge7VfPDwX"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548592562393, :id "zVCuJbq_qD"
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105355801, :id "xuRY-eqWEq"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592563471, :text "{}", :id "P1GknwqNQn"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105355801, :text ":template-id", :id "B8YlrFbIxW"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105355801, :text "template-id", :id "3uaDzLSfnh"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105355801, :id "hwj7Tlr3oR"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105355801, :text ":mock-id", :id "e-atcqNdfk"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548592563738, :id "eM9ay2ugO4"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105355801, :id "oFLWtHp4OX"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592566815, :text ":padding", :id "BIkl07pps"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551116418, :text "\"4px 8px", :id "Fn_UtGs3tK"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105355801, :text ":id", :id "qEbRNCCEJH"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105355801, :text "mock", :id "hK6c8IF-X3"}
                   }
                  }
                 }
@@ -9815,235 +10265,292 @@
              }
             }
            }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548594045133, :id "W-gMazQs-J"
+          }
+         }
+         "T" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548592405659, :id "D_ZdR7KZ95"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592460217, :text "div", :id "yLxyafjVwa"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548592405659, :id "7-tFtHCoEl"
             :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594048043, :text "cursor->", :id "ykDQ3YBi8"}
-             "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594053149, :text ":rename", :id "XUZA_z4AFi"}
-             "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594057569, :text "comp-prompt", :id "aLCDIvnaeG"}
-             "R" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594061058, :text "states", :id "JsdMMDy5fI"}
-             "T" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548594062319, :id "vnh-RTgaPB"
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592405659, :text "{}", :id "IseHGe7-2U"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548592461724, :id "2aDpMGCCx6"
               :data {
-               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594062756, :text "{}", :id "8cJmUY_-i"}
-               "T" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548594063413, :id "8C4ksUBf3w"
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592462459, :text ":style", :id "QZgbP1qhZ"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548592487482, :id "eD1gA4Qqjm"
                 :data {
-                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594065224, :text ":trigger", :id "ty1H7x4Zc"}
-                 "T" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548594138170, :id "TQI_XFxwT_"
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592490195, :text "merge", :id "5KhNk55S1"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592464447, :text "ui/flex", :id "l8RO2gfO5"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592495458, :text "ui/column", :id "0z_N04NCjV"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548592473589, :id "8L23dUFib"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592474808, :text "div", :id "8L23dUFibleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548592475079, :id "O0aTWOaGHa"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592475394, :text "{}", :id "vc_AVZMDgQ"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548592560542, :id "W7K7pZM0C"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592562145, :text ":style", :id "GJTeDUU0eo"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548592562393, :id "zVCuJbq_qD"
                   :data {
-                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594214428, :text "div", :id "S-uICrS7Jh"}
-                   "L" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548594140409, :id "iHnaEK60-V"
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592563471, :text "{}", :id "P1GknwqNQn"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548592563738, :id "eM9ay2ugO4"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594140731, :text "{}", :id "5Gsc5HFDrD"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548594208933, :id "XyyZsJF1VE"
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592566815, :text ":padding", :id "BIkl07pps"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551116418, :text "\"4px 8px", :id "Fn_UtGs3tK"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548594045133, :id "W-gMazQs-J"
+              :data {
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594048043, :text "cursor->", :id "ykDQ3YBi8"}
+               "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594053149, :text ":rename", :id "XUZA_z4AFi"}
+               "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594057569, :text "comp-prompt", :id "aLCDIvnaeG"}
+               "R" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594061058, :text "states", :id "JsdMMDy5fI"}
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548594062319, :id "vnh-RTgaPB"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594062756, :text "{}", :id "8cJmUY_-i"}
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548594063413, :id "8C4ksUBf3w"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594065224, :text ":trigger", :id "ty1H7x4Zc"}
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548594138170, :id "TQI_XFxwT_"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594214428, :text "div", :id "S-uICrS7Jh"}
+                     "L" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548594140409, :id "iHnaEK60-V"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594210138, :text ":style", :id "FV4dXnTs9O"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594212864, :text "ui/row-middle", :id "BdSQ2WtIdy"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594140731, :text "{}", :id "5Gsc5HFDrD"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548594208933, :id "XyyZsJF1VE"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594210138, :text ":style", :id "FV4dXnTs9O"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594212864, :text "ui/row-middle", :id "BdSQ2WtIdy"}
+                        }
+                       }
                       }
                      }
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548592546728, :id "p8GEiOePrp"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592547384, :text "<>", :id "p8GEiOePrpleaf"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548592550152, :id "Mgo32WQ3SB"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592551682, :text ":name", :id "XDF-ZUAoz"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592553345, :text "mock", :id "9YpWqpSRfd"}
+                        }
+                       }
+                      }
+                     }
+                     "b" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548594218334, :id "ad8bikP-L"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594219410, :text "=<", :id "ad8bikP-Lleaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594220489, :text "8", :id "9_ApgrbO5"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594220981, :text "nil", :id "metrJM4Ck"}
+                      }
+                     }
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548594141789, :id "IOD0lScp6A"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594144053, :text "comp-i", :id "IOD0lScp6Aleaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594194086, :text ":edit", :id "6oK3pGlan"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594195294, :text "14", :id "BOz08HwvQs"}
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548594196157, :id "DskDrbITp"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594196649, :text "hsl", :id "t0-xVIX7vx"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594198777, :text "200", :id "L3scFjP386"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594199214, :text "80", :id "-Wjq-Kg5h4"}
+                         "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594200293, :text "60", :id "fZAi3kMIRF"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548594126270, :id "vkA2vXQkIJ"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594128064, :text ":initial", :id "vkA2vXQkIJleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548594128793, :id "16UzKCDv6x"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594130959, :text ":name", :id "X1_SwDBXv"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594131350, :text "mock", :id "XJ7ePknnWP"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548594066049, :id "2F3hTfkVki"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594066348, :text "fn", :id "2F3hTfkVkileaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548594066554, :id "n7fM8JtId"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594067936, :text "result", :id "3cF24Se7Ck"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594069044, :text "d!", :id "IoYeI2yQYe"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594070100, :text "m!", :id "YcQIxPSiFc"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548594104744, :id "3NOkFTnmo"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594106970, :text "when-not", :id "C1YT-IaiPv"}
+                   "L" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548594107418, :id "L-YfqAaNhJ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594112938, :text "string/blank?", :id "wR1CFSVaLC"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594114418, :text "result", :id "FBlnUgKaZY"}
                     }
                    }
                    "T" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548592546728, :id "p8GEiOePrp"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548594070941, :id "5wRoEFMioO"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592547384, :text "<>", :id "p8GEiOePrpleaf"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548592550152, :id "Mgo32WQ3SB"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592551682, :text ":name", :id "XDF-ZUAoz"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592553345, :text "mock", :id "9YpWqpSRfd"}
-                      }
-                     }
-                    }
-                   }
-                   "b" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548594218334, :id "ad8bikP-L"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594219410, :text "=<", :id "ad8bikP-Lleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594220489, :text "8", :id "9_ApgrbO5"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594220981, :text "nil", :id "metrJM4Ck"}
-                    }
-                   }
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548594141789, :id "IOD0lScp6A"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594144053, :text "comp-i", :id "IOD0lScp6Aleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594194086, :text ":edit", :id "6oK3pGlan"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594195294, :text "14", :id "BOz08HwvQs"}
-                     "v" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548594196157, :id "DskDrbITp"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594196649, :text "hsl", :id "t0-xVIX7vx"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594198777, :text "200", :id "L3scFjP386"}
-                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594199214, :text "80", :id "-Wjq-Kg5h4"}
-                       "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594200293, :text "60", :id "fZAi3kMIRF"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548594126270, :id "vkA2vXQkIJ"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594128064, :text ":initial", :id "vkA2vXQkIJleaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548594128793, :id "16UzKCDv6x"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594130959, :text ":name", :id "X1_SwDBXv"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594131350, :text "mock", :id "XJ7ePknnWP"}
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548594066049, :id "2F3hTfkVki"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594066348, :text "fn", :id "2F3hTfkVkileaf"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548594066554, :id "n7fM8JtId"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594067936, :text "result", :id "3cF24Se7Ck"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594069044, :text "d!", :id "IoYeI2yQYe"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594070100, :text "m!", :id "YcQIxPSiFc"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548594104744, :id "3NOkFTnmo"
-                :data {
-                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594106970, :text "when-not", :id "C1YT-IaiPv"}
-                 "L" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548594107418, :id "L-YfqAaNhJ"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594112938, :text "string/blank?", :id "wR1CFSVaLC"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594114418, :text "result", :id "FBlnUgKaZY"}
-                  }
-                 }
-                 "T" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548594070941, :id "5wRoEFMioO"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594073271, :text "d!", :id "5wRoEFMioOleaf"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594080233, :text ":template/rename-mock", :id "TAg7nSWkHn"}
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548594081564, :id "4zRXqe5DW"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594081872, :text "{}", :id "ibNwS5gdU"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548594082040, :id "D7BjysqIyu"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594089652, :text ":template-id", :id "vZAqROpHRO"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594091581, :text "template-id", :id "cEnnZGLmtY"}
-                      }
-                     }
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594073271, :text "d!", :id "5wRoEFMioOleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594080233, :text ":template/rename-mock", :id "TAg7nSWkHn"}
                      "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548594092379, :id "JIzECb0CVM"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548594081564, :id "4zRXqe5DW"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594094082, :text ":mock-id", :id "JIzECb0CVMleaf"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594081872, :text "{}", :id "ibNwS5gdU"}
                        "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548594095517, :id "WtMRvZ98me"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548594082040, :id "D7BjysqIyu"
                         :data {
-                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594096321, :text ":id", :id "s_1vnJ5lW"}
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594095036, :text "mock", :id "ibCOE6GYGb"}
-                        }
-                       }
-                      }
-                     }
-                     "v" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548594097375, :id "4w0vh87bO7"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594101229, :text ":text", :id "4w0vh87bO7leaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594103525, :text "result", :id "0dvfcDyFJo"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "t" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551551188919, :id "gHtLiStrrt"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551188919, :text "=<", :id "O5X015WxVm"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551202095, :text "40", :id "8FH3Srlqip"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551188919, :text "nil", :id "306Sinjp5p"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "rL2NXz1cPo"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "a", :id "IuycOPmP8p"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "WQ7imkbYK9"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "{}", :id "ATU7jHkERi"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "pIwegFq_g0"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":style", :id "NXZ1xsXYuw"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "ui/link", :id "3YHI0KXpD_"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "eSK88KNT7S"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":inner-text", :id "AAduAPo5Do"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103325552, :text "\"Use it", :id "bmtrpqaKM5"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "i5m8u-tOe1"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":on-click", :id "dcqpfPNw2y"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "Og1U-GwLJs"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "fn", :id "vOPbtlEfYRH"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "A3WMb78ZGf6"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "e", :id "P9Li-NU1ujQ"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "d!", :id "cJHcthKzmZl"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "m!", :id "bJnYOKtLSIR"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "OrYX_FH0i1Z"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "d!", :id "kVPar1ZTnuG"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":template/use-mock", :id "32VWTXOtdTh"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "05R_HXDxpYc"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "{}", :id "ULOHQ5IGdVX"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "TuAkss-5wiX"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":template-id", :id "oKeDtIEIndm"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "template-id", :id "556lPOL42WQ"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594089652, :text ":template-id", :id "vZAqROpHRO"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594091581, :text "template-id", :id "cEnnZGLmtY"}
                         }
                        }
                        "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "ZRvIF4GCeY8"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548594092379, :id "JIzECb0CVM"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":mock-id", :id "ONPaFh1EePm"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594094082, :text ":mock-id", :id "JIzECb0CVMleaf"}
                          "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "NMj_agnrcHc"
+                          :type :expr, :by "B1y7Rc-Zz", :at 1548594095517, :id "WtMRvZ98me"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":id", :id "CZ9pnSvvinm"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "mock", :id "sBDxsWXazgV"}
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594096321, :text ":id", :id "s_1vnJ5lW"}
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594095036, :text "mock", :id "ibCOE6GYGb"}
+                          }
+                         }
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548594097375, :id "4w0vh87bO7"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594101229, :text ":text", :id "4w0vh87bO7leaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548594103525, :text "result", :id "0dvfcDyFJo"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "t" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551551188919, :id "gHtLiStrrt"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551188919, :text "=<", :id "O5X015WxVm"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551202095, :text "40", :id "8FH3Srlqip"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551188919, :text "nil", :id "306Sinjp5p"}
+              }
+             }
+             "v" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "rL2NXz1cPo"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "a", :id "IuycOPmP8p"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "WQ7imkbYK9"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "{}", :id "ATU7jHkERi"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "pIwegFq_g0"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":style", :id "NXZ1xsXYuw"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "ui/link", :id "3YHI0KXpD_"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "eSK88KNT7S"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":inner-text", :id "AAduAPo5Do"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103325552, :text "\"Use it", :id "bmtrpqaKM5"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "i5m8u-tOe1"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":on-click", :id "dcqpfPNw2y"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "Og1U-GwLJs"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "fn", :id "vOPbtlEfYRH"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "A3WMb78ZGf6"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "e", :id "P9Li-NU1ujQ"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "d!", :id "cJHcthKzmZl"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "m!", :id "bJnYOKtLSIR"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "OrYX_FH0i1Z"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "d!", :id "kVPar1ZTnuG"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":template/use-mock", :id "32VWTXOtdTh"}
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "05R_HXDxpYc"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "{}", :id "ULOHQ5IGdVX"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "TuAkss-5wiX"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":template-id", :id "oKeDtIEIndm"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "template-id", :id "556lPOL42WQ"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "ZRvIF4GCeY8"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":mock-id", :id "ONPaFh1EePm"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1551551176344, :id "NMj_agnrcHc"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text ":id", :id "CZ9pnSvvinm"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551176344, :text "mock", :id "sBDxsWXazgV"}
+                            }
+                           }
                           }
                          }
                         }
@@ -10058,234 +10565,541 @@
                }
               }
              }
-            }
-           }
-           "w" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551551187883, :id "JqSnSJVLXs"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "=<", :id "pNPsJk9J_v"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "8", :id "dL33qX_uDz"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "nil", :id "ybnq2N3XhC"}
-            }
-           }
-           "wD" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553103336767, :id "1lIQxpOXg"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103338346, :text "cursor->", :id "1lIQxpOXgleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103348510, :text ":fork", :id "7QgIetmZC"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103353373, :text "comp-prompt", :id "1wKe67T2B"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103354696, :text "states", :id "6V8DyXE05"}
-             "x" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1553103355355, :id "cyoylQCsMc"
+             "w" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551551187883, :id "JqSnSJVLXs"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103355715, :text "{}", :id "lqidQl66zJ"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1553103356838, :id "XPRBtEQsy"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103358114, :text ":trigger", :id "9fohxv5hYJ"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "Bm-T9EHluK"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "a", :id "IM2_ntColL"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "DDhHEQttHp"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "{}", :id "N69IDjk7qY"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "ICnrV9_dEu"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text ":style", :id "i6kq_BqIca"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "ui/link", :id "3laiNwgT85"}
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "k5hDjJbrfE"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text ":inner-text", :id "NNFB1nx-wd"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103364126, :text "\"Fork", :id "pH-BTTPafz"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1553103368066, :id "UZSqcUHQon"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103369671, :text ":text", :id "UZSqcUHQonleaf"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103378877, :text "\"Fork with new name:", :id "xLFQo-Jl3m"}
-                }
-               }
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "=<", :id "pNPsJk9J_v"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "8", :id "dL33qX_uDz"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "nil", :id "ybnq2N3XhC"}
               }
              }
-             "y" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1553103381557, :id "xZ4EGrzup"
+             "wD" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553103336767, :id "1lIQxpOXg"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103382609, :text "fn", :id "xZ4EGrzupleaf"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1553103383021, :id "BHLmVT8keO"
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103338346, :text "cursor->", :id "1lIQxpOXgleaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103348510, :text ":fork", :id "7QgIetmZC"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103353373, :text "comp-prompt", :id "1wKe67T2B"}
+               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103354696, :text "states", :id "6V8DyXE05"}
+               "x" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103355355, :id "cyoylQCsMc"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103388305, :text "result", :id "S25wSeIs0J"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103384199, :text "d!", :id "-kylNYIUx"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103385698, :text "m!", :id "hG-RvPuND"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1553103388827, :id "Ycdxav4iAB"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103391757, :text "when-not", :id "Ycdxav4iABleaf"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103355715, :text "{}", :id "lqidQl66zJ"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1553103392090, :id "c9jSfGu3h9"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103356838, :id "XPRBtEQsy"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103397954, :text "string/blank?", :id "rLWTiFc5ah"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103400560, :text "result", :id "5LktjMRXE"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1553103401543, :id "Q7_UxRbZA"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103404178, :text "d!", :id "Q7_UxRbZAleaf"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103411123, :text ":template/fork-mock", :id "SG1BK0SZRV"}
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1553103411938, :id "pW_CfaQj8q"
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103358114, :text ":trigger", :id "9fohxv5hYJ"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "Bm-T9EHluK"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103412317, :text "{}", :id "SEdOu9GhK"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "a", :id "IM2_ntColL"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553103412606, :id "6O8SZ2RyP"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "DDhHEQttHp"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103420194, :text ":template-id", :id "C1sKfmm0Mb"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103415767, :text "template-id", :id "kTwGzrk1cX"}
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553103421049, :id "J9EhOUl9hV"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103424816, :text ":mock-id", :id "J9EhOUl9hVleaf"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "{}", :id "N69IDjk7qY"}
                        "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1553103428710, :id "cMVlJVt5r"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "ICnrV9_dEu"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103426015, :text ":id", :id "ZRl6NKLr7v"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103431538, :text "mock", :id "Hxh7qtcAqy"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text ":style", :id "i6kq_BqIca"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text "ui/link", :id "3laiNwgT85"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103361609, :id "k5hDjJbrfE"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103361609, :text ":inner-text", :id "NNFB1nx-wd"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103364126, :text "\"Fork", :id "pH-BTTPafz"}
                         }
                        }
                       }
                      }
-                     "v" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553103434373, :id "XC6gZLGcK7"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103438850, :text ":name", :id "XC6gZLGcK7leaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103441684, :text "result", :id "Znw14MPIK"}
-                      }
-                     }
                     }
                    }
                   }
                  }
-                }
-               }
-              }
-             }
-            }
-           }
-           "wT" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551551187883, :id "_PivaZw-0"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "=<", :id "pNPsJk9J_v"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "8", :id "dL33qX_uDz"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "nil", :id "ybnq2N3XhC"}
-            }
-           }
-           "x" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551551450677, :id "rWVv8faVI"
-            :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551455251, :text "cursor->", :id "1bwGVYuLaW"}
-             "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551459549, :text ":remove", :id "ECetxcCMMj"}
-             "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551462054, :text "comp-confirm", :id "87r9Fr0Kgi"}
-             "R" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551463807, :text "states", :id "WnPzxYbQZ"}
-             "S" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551551465819, :id "jWtDeuq4Y_"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551466144, :text "{}", :id "KzS-wqCzp"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551466399, :id "bdcTJ-DleX"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551467424, :text ":trigger", :id "sR8pieHs-W"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "IjNjBo4zpW"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "a", :id "AwpdNs8v5l"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "Ffc2ncaHJD"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "{}", :id "UZCvN4LcJ8"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "b4bVujpYGn"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text ":style", :id "Cwq5T3Sip9"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "ui/link", :id "gNMKxXsme4"}
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "qSOCPbJJU2"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text ":inner-text", :id "yfevrgOtXy"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "\"Remove", :id "KAmtSWBJE4"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551478408, :id "g2dIvip0su"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551480668, :text ":text", :id "g2dIvip0suleaf"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551493182, :text "\"Sure to remove mock data?", :id "Ot8XwBfae2"}
-                }
-               }
-              }
-             }
-             "ST" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551551497729, :id "fmOUYCPzW"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551498515, :text "fn", :id "fmOUYCPzWleaf"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551499351, :id "ue2nTfLack"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551505963, :text "e", :id "bmx9eIeHr"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551506706, :text "d!", :id "vhNkGNr7ol"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551507458, :text "m!", :id "FL16zb6_8W"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "IohuOF5s4l"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "d!", :id "2936AsvKfo"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":template/remove-mock", :id "8O9N2_g8Ps"}
                  "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "WPnWxFmUU2"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103368066, :id "UZSqcUHQon"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "{}", :id "JDOfsyVI2b"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103369671, :text ":text", :id "UZSqcUHQonleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103378877, :text "\"Fork with new name:", :id "xLFQo-Jl3m"}
+                  }
+                 }
+                }
+               }
+               "y" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553103381557, :id "xZ4EGrzup"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103382609, :text "fn", :id "xZ4EGrzupleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103383021, :id "BHLmVT8keO"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103388305, :text "result", :id "S25wSeIs0J"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103384199, :text "d!", :id "-kylNYIUx"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103385698, :text "m!", :id "hG-RvPuND"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553103388827, :id "Ycdxav4iAB"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103391757, :text "when-not", :id "Ycdxav4iABleaf"}
                    "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "_oynicTvfH"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103392090, :id "c9jSfGu3h9"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":template-id", :id "SqoQZBy5RL"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "template-id", :id "dOpI85XueZ"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103397954, :text "string/blank?", :id "rLWTiFc5ah"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103400560, :text "result", :id "5LktjMRXE"}
                     }
                    }
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "vlsBEVBbaq"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553103401543, :id "Q7_UxRbZA"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":mock-id", :id "J_YJBDLdPP"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "i9jytF7mR-"
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103404178, :text "d!", :id "Q7_UxRbZAleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103411123, :text ":template/fork-mock", :id "SG1BK0SZRV"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553103411938, :id "pW_CfaQj8q"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":id", :id "k9MfM9BIUD"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "mock", :id "N8i3m5erQ3"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103412317, :text "{}", :id "SEdOu9GhK"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103412606, :id "6O8SZ2RyP"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103420194, :text ":template-id", :id "C1sKfmm0Mb"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103415767, :text "template-id", :id "kTwGzrk1cX"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103421049, :id "J9EhOUl9hV"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103424816, :text ":mock-id", :id "J9EhOUl9hVleaf"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553103428710, :id "cMVlJVt5r"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103426015, :text ":id", :id "ZRl6NKLr7v"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103431538, :text "mock", :id "Hxh7qtcAqy"}
+                          }
+                         }
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553103434373, :id "XC6gZLGcK7"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103438850, :text ":name", :id "XC6gZLGcK7leaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553103441684, :text "result", :id "Znw14MPIK"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "wT" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551551187883, :id "_PivaZw-0"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "=<", :id "pNPsJk9J_v"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "8", :id "dL33qX_uDz"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551187883, :text "nil", :id "ybnq2N3XhC"}
+              }
+             }
+             "x" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551551450677, :id "rWVv8faVI"
+              :data {
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551455251, :text "cursor->", :id "1bwGVYuLaW"}
+               "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551459549, :text ":remove", :id "ECetxcCMMj"}
+               "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551462054, :text "comp-confirm", :id "87r9Fr0Kgi"}
+               "R" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551463807, :text "states", :id "WnPzxYbQZ"}
+               "S" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1551551465819, :id "jWtDeuq4Y_"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551466144, :text "{}", :id "KzS-wqCzp"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551466399, :id "bdcTJ-DleX"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551467424, :text ":trigger", :id "sR8pieHs-W"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "IjNjBo4zpW"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "a", :id "AwpdNs8v5l"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "Ffc2ncaHJD"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "{}", :id "UZCvN4LcJ8"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "b4bVujpYGn"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text ":style", :id "Cwq5T3Sip9"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "ui/link", :id "gNMKxXsme4"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1551551472287, :id "qSOCPbJJU2"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text ":inner-text", :id "yfevrgOtXy"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551472287, :text "\"Remove", :id "KAmtSWBJE4"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551478408, :id "g2dIvip0su"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551480668, :text ":text", :id "g2dIvip0suleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551493182, :text "\"Sure to remove mock data?", :id "Ot8XwBfae2"}
+                  }
+                 }
+                }
+               }
+               "ST" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1551551497729, :id "fmOUYCPzW"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551498515, :text "fn", :id "fmOUYCPzWleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551499351, :id "ue2nTfLack"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551505963, :text "e", :id "bmx9eIeHr"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551506706, :text "d!", :id "vhNkGNr7ol"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551507458, :text "m!", :id "FL16zb6_8W"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "IohuOF5s4l"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "d!", :id "2936AsvKfo"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":template/remove-mock", :id "8O9N2_g8Ps"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "WPnWxFmUU2"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "{}", :id "JDOfsyVI2b"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "_oynicTvfH"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":template-id", :id "SqoQZBy5RL"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "template-id", :id "dOpI85XueZ"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "vlsBEVBbaq"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":mock-id", :id "J_YJBDLdPP"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1551551511652, :id "i9jytF7mR-"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text ":id", :id "k9MfM9BIUD"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551511652, :text "mock", :id "N8i3m5erQ3"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553106152198, :id "uZR5xyqE1n"
+            :data {
+             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106152868, :text "div", :id "kqaOWivmfN"}
+             "L" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553106153064, :id "Dd3jjanGsp"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106154832, :text "{}", :id "_46Ni5m2ci"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553106156594, :id "Uarj73c78"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106157380, :text ":style", :id "ovqieHYn41"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553106159206, :id "t5oMxsn0Z-"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106158962, :text "{}", :id "T7z-yu-NT3"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106160661, :id "G-SJMpOHW"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106161590, :text ":padding", :id "3cyXwjNLg"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106263350, :text "\"0px 8px", :id "3AOaU6AK2p"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106297550, :id "zklQ6ozrW"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106299514, :text ":max-height", :id "zklQ6ozrWleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106301565, :text "320", :id "FiILgSaMc"}
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106304938, :id "YqHs_PE-j"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106307360, :text ":overflow", :id "wURk_HjvAg"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106308169, :text ":auto", :id "lNQ1FPaTCr"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "T" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "_dyP-BSITG"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "pre", :id "0CK7Z4yDVi"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "c5Y7UkjP53"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "{}", :id "dh1tgc-BKT"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "cSPQaYGfpu"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text ":style", :id "X2EwtMfzk5"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "oF1NaVKWz6"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "merge", :id "XZ0Rq9aAC2"}
+                     "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106125196, :text "style-code", :id "YBS9iJX9NK"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "zgzm2iRe_h"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "{}", :id "ceAcnIlFgp"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106146921, :id "LomDYwigAg"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106148263, :text ":width", :id "mLSmh5njm"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106150387, :text "\"100%", :id "-X4L1BNiQ4"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106183904, :id "p4B_4DZuP"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106185771, :text ":margin", :id "p4B_4DZuPleaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106186536, :text "0", :id "4FhuDdA9KQ"}
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106228383, :id "fZHUZzlrt"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106234107, :text ":background-color", :id "fZHUZzlrtleaf"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553106234356, :id "_5D9lpARfB"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106234716, :text "hsl", :id "Eql7ZNSahU"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106235128, :text "0", :id "mlXoR6FAhY"}
+                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106235376, :text "0", :id "IPZqYZ1ghK"}
+                           "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106270022, :text "96", :id "0vT22e1bEb"}
+                          }
+                         }
+                        }
+                       }
+                       "x" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553106244443, :id "8cQGNTqNMO"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106246916, :text ":padding", :id "8cQGNTqNMOleaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106249494, :text "\"4px 8px", :id "lEvkLrEn_p"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "5oWdWPL_VDF"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text ":disabled", :id "sziA5lclEJ_"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "true", :id "xYQzkquTWtz"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "3sdyDy-cIMx"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text ":inner-text", :id "Luy4yZESKZ5"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "6ewio632igf"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "write-edn", :id "4NRjgS2Z_mn"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553106112795, :id "j6vZRgHx6-U"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text ":data", :id "iy_CeE7tTT5"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106112795, :text "mock", :id "E9bmADqKQN9"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553105146346, :id "tgzaOpFd9"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105147542, :text "div", :id "tgzaOpFd9leaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105148825, :id "UjtooXFS34"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105149269, :text "{}", :id "w9b1cwbSL"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105150993, :id "PYM8tobMTj"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105153134, :text ":style", :id "jGg-aPe6b"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105153345, :id "_iJbdJ4-va"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105154468, :text "{}", :id "tTpYDpedtd"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105154768, :id "Oa6m_O7fuW"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105156853, :text ":padding", :id "nhY5KVoPO"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105159672, :text "8", :id "jr9vTY4nuw"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553105220876, :id "YLjSRJ4GA"
+              :data {
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105225602, :text "cursor->", :id "g7BsujqoPx"}
+               "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105226725, :text ":edit", :id "2TxBHGsojW"}
+               "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105230855, :text "comp-popup", :id "LaLCp4QJk"}
+               "R" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105250773, :text "states", :id "WEG7U6BHf"}
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105252889, :id "Cn-lU-ucOP"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105253440, :text "{}", :id "iDq2xKFzVU"}
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105253933, :id "28hK6ZwrvV"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105255409, :text ":trigger", :id "_mcEd_HlH6"}
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105162011, :id "oa3P0_TQDL"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105171121, :text "a", :id "oa3P0_TQDLleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105172087, :id "SJ3T_kxKLE"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105172787, :text "{}", :id "JCmIIR-a8P"}
+                       "L" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553105179983, :id "zX2PiZWqwG"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105181479, :text ":style", :id "zX2PiZWqwGleaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105183362, :text "ui/link", :id "9q1dqpiDE"}
+                        }
+                       }
+                       "T" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553105173328, :id "iO7Ew8cqJl"
+                        :data {
+                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105179014, :text ":inner-text", :id "jSyKyf9ti"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105168340, :text "\"Edit data", :id "kjw9mhZ0F"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105256610, :id "lHvcMUcI-"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105261655, :text ":style", :id "lHvcMUcI-leaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105262299, :text "nil", :id "XdrEmiKEca"}
+                  }
+                 }
+                }
+               }
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553105263344, :id "xtsnRRQW22"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105264212, :text "fn", :id "xtsnRRQW22leaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105264679, :id "3bYKmh6nv"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105268388, :text "on-toggle", :id "2SLs0Eo3Kw"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553105268920, :id "WNwZ6iTRdu"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105301986, :text "cursor->", :id "b1hKy9sM5"}
+                   "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105304942, :text ":edit-data", :id "VgznK92ro"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105421249, :text "comp-data-editor", :id "WNwZ6iTRduleaf"}
+                   "X" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105439741, :text "states", :id "0i5muLBW7"}
+                   "b" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105448506, :id "QSUJ8nKiw"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105452988, :text ":data", :id "n129G5Wa5"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105407201, :text "mock", :id "g53J0Sqaq"}
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553105374048, :id "8opss_kcCL"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105373809, :text "fn", :id "xz9HZMl_7"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105374849, :id "Vfcxwl1d50"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105455338, :text "data", :id "DK12Lk9d-"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105816922, :text "d!", :id "CYCZPtfvlx"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105865673, :text "m!", :id "xfX004vC7C"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105397367, :id "B-hLY5eTk-"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105400017, :text "println", :id "B-hLY5eTk-leaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105402628, :text "\"edit data", :id "UxtgbxP_r"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105456474, :text "data", :id "81BtC24Dc"}
+                      }
+                     }
+                     "v" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105718004, :id "Z2R582mfRv"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105718004, :text "d!", :id "pI38ekgBJM"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105718004, :text ":template/update-mock", :id "3XYqYOZ9Pu"}
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553105723566, :id "MUJQ5YVgV"
+                        :data {
+                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105724709, :text "merge", :id "RDmov8eVaS"}
+                         "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105727291, :text "base-op-data", :id "vVwJRN_EhT"}
+                         "P" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553105729197, :id "acJSbzmWhi"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105729584, :text "{}", :id "3HXr2DOni"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553105729920, :id "qZ2eZpI8L6"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105889206, :text ":data", :id "lJ-PdiMbM_"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105732231, :text "data", :id "ailfJUFlks"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                     "x" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553105738074, :id "IPH40lsb7i"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105739961, :text "on-toggle", :id "IPH40lsb7ileaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553105868226, :text "m!", :id "jEdgsyRgOj"}
                       }
                      }
                     }
@@ -10300,313 +11114,38 @@
            }
           }
          }
+        }
+       }
+      }
+     }
+     "style-code" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1553106092257, :id "juDCiGeCgG"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text "def", :id "Xl7QW7T6Nd"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text "style-code", :id "R5-UmMmNx4"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1553106092257, :id "YDUio_Z8Xu"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text "{}", :id "MTeiCqvady"}
          "v" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548592478798, :id "Sg8OVC1RYy"
+          :type :expr, :by "B1y7Rc-Zz", :at 1553106092257, :id "o8Q84J_dRI"
           :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592479268, :text "div", :id "Sg8OVC1RYyleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548592479483, :id "WtetoAUBE0"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592479759, :text "{}", :id "4iZiUXEQZB"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548592541620, :id "2YWEmmR9r"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592543065, :text ":style", :id "6FwGwvXOvc"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592544544, :text "ui/flex", :id "KqfuAsrsBN"}
-              }
-             }
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548592878539, :id "ZxRIVGjaQ"
-            :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592880512, :text "cursor->", :id "eKmA0LMyAe"}
-             "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592892478, :text ":data", :id "o3AY3T3Lx"}
-             "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592895029, :text "comp-prompt", :id "TaG42TuBm"}
-             "R" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592898582, :text "states", :id "aoCfsMqPLb"}
-             "T" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548592925017, :id "XCOQ661Yv"
-              :data {
-               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592925635, :text "{}", :id "QEviN0TWO1"}
-               "T" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548592926141, :id "VbeCG-sgS5"
-                :data {
-                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592928104, :text ":trigger", :id "3OK7LyA9Mw"}
-                 "T" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548592591037, :id "USEaqhC5Gv"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592974462, :text "pre", :id "USEaqhC5Gvleaf"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548592592840, :id "upYjLBJ2Ry"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592593115, :text "{}", :id "j5bDbmgqT"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548592597904, :id "NmVgm3MM91"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592598564, :text ":style", :id "fWH9erEhk"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548592807552, :id "vCb5DSXGL"
-                        :data {
-                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592808405, :text "merge", :id "hMo-bhPkkk"}
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592600985, :text "ui/textarea", :id "nkGMj31M61"}
-                         "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548592808974, :id "f5I3PCvAPk"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592809263, :text "{}", :id "ZGN6rSDcPR"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1548592809470, :id "Otag5x0Mli"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592812251, :text ":font-family", :id "wDjl_PGwgE"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592814027, :text "ui/font-code", :id "Z_QulaJlvj"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1548592821730, :id "nusNkOqpx"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592822624, :text ":width", :id "nusNkOqpxleaf"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592824289, :text "\"100%", :id "3kGrJvL6im"}
-                            }
-                           }
-                           "v" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551551022076, :id "SHoaKeElB6"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551026418, :text ":line-height", :id "SHoaKeElB6leaf"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551038280, :text "\"20px", :id "iSyoa9IRs"}
-                            }
-                           }
-                           "x" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551551058738, :id "LWg-GNYHh"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551060207, :text ":font-size", :id "LWg-GNYHhleaf"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551551069502, :text "13", :id "OcT4w9NIq"}
-                            }
-                           }
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                     "n" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548592800013, :id "X3D-Nt93is"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592803654, :text ":disabled", :id "X3D-Nt93isleaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592804307, :text "true", :id "jaUxBySvbC"}
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548592790151, :id "GTt5vlNZ4"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592989255, :text ":inner-text", :id "GTt5vlNZ4leaf"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548592791292, :id "jw_0I1p7t0"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592791611, :text "write-edn", :id "RlFgftzUYl"}
-                         "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548592793430, :id "cuoBdNG5y"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592794555, :text ":data", :id "vwloHHkgNs"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592795241, :text "mock", :id "SHcxpO4GdA"}
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "b" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548593613219, :id "pblRc-o6aO"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593616703, :text ":style", :id "pblRc-o6aOleaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548593616985, :id "2ec_PTvmFz"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593617295, :text "{}", :id "JF45t_x8ah"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593617480, :id "s67mKKJymD"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593618243, :text ":width", :id "MBmeYZsKpj"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593619987, :text "\"100%", :id "Ca_xdNwfY"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593624818, :id "o7vV6dQMpx"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593626316, :text ":padding", :id "o7vV6dQMpxleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593632459, :text "\"0 8px", :id "EQ1p0-pgqE"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548593007211, :id "EqJFyPZRCd"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593017549, :text ":multiline?", :id "EqJFyPZRCdleaf"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593441220, :text "true", :id "GZtYTkpNYb"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548593386645, :id "2wmEBWL7D"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593431839, :text ":input-style", :id "2wmEBWL7Dleaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548593387760, :id "hWmOfMURmH"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593388091, :text "{}", :id "niU0f53Q64"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593388331, :id "L6BrllaZtI"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593392319, :text ":font-family", :id "bFISLFll5Z"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593394896, :text "ui/font-code", :id "rP0RXg43Vd"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548593558281, :id "q_Pb45I7qH"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593560456, :text ":initial", :id "q_Pb45I7qHleaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548593560779, :id "hw3z3wuqbj"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593565302, :text "write-edn", :id "M0oz2LMrd"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593565970, :id "6SN_GVQNIv"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593567855, :text ":data", :id "kQ1nz9mzX"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593578916, :text "mock", :id "iZ0wGPmoV2"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548592929108, :id "3h2C49g6b0"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592929454, :text "fn", :id "3h2C49g6b0leaf"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548592929722, :id "selKNwHSaX"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592933527, :text "result", :id "k3WoygDds"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592934149, :text "d!", :id "Edtehsu4FE"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548592935246, :text "m!", :id "otnTqcFZ_P"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548593166113, :id "N_aQXRUXAf"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593167598, :text "try", :id "N_aQXRUXAfleaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548593169757, :id "iZ7GZXekyt"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593173171, :text "do", :id "r3lK0ouUX"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593206867, :id "9eX1LylQm"
-                    :data {
-                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593213241, :text "let", :id "FtaJDkF1DB"}
-                     "T" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548593215384, :id "W7qvdeFuvV"
-                      :data {
-                       "T" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548593213657, :id "ZLb3Ws9zt"
-                        :data {
-                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593215008, :text "data", :id "CwbTIPWhl2"}
-                         "T" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548593190344, :id "o--uvYXgE9"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593203503, :text "read-string", :id "NatsuSGf9V"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593205311, :text "result", :id "jQu4-4Duo"}
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548593294292, :id "NpwddzfDgB"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593295180, :text "d!", :id "NpwddzfDgBleaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593304243, :text ":template/update-mock", :id "sPa8vPoHw6"}
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548593304527, :id "edM5ti0s-"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593304852, :text "{}", :id "QKZBT0dtzD"}
-                         "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548593305225, :id "TIwvvw265d"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593310411, :text ":template-id", :id "RjaRehNaL-"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593312223, :text "template-id", :id "2g8ddzWbnW"}
-                          }
-                         }
-                         "r" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548593312765, :id "tp4YLPxpl"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593314072, :text ":mock-id", :id "tp4YLPxplleaf"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1548593319689, :id "F9iJPjF44K"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593319536, :text ":id", :id "nwQKsVLEWW"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593320349, :text "mock", :id "71RLVTHnpm"}
-                            }
-                           }
-                          }
-                         }
-                         "v" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1548593321235, :id "LxR__yQPNe"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593322703, :text ":data", :id "LxR__yQPNeleaf"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593323566, :text "data", :id "E6es1BKXjm"}
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548593173798, :id "5Uq1TZZTg7"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593174947, :text "catch", :id "5Uq1TZZTg7leaf"}
-                   "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593252619, :text "js/Error", :id "Etn3ANDHFa"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593175994, :text "err", :id "eYhOHKQp_j"}
-                   "p" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593331675, :id "g6DGuBCaO"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593333172, :text ".error", :id "g6DGuBCaOleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593335775, :text "js/console", :id "wKJ7fF0S5j"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593337600, :text "err", :id "ddmLGe-gm"}
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548593179743, :id "jEWTtELzY"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593183836, :text "js/alert", :id "Hyv_jeLQ6"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548593188161, :text "\"Invalid data", :id "1jRTFdPhD"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text ":font-family", :id "YwGJiIIdFs"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text "ui/font-code", :id "Lveg7kaKDg"}
+          }
+         }
+         "x" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553106092257, :id "E14-vVCS7m"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text ":font-size", :id "sNeA0BFU-SI"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106092257, :text "12", :id "lbm5_hJq0tu"}
+          }
+         }
+         "y" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553106345046, :id "nqFY4YkfKF"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106348045, :text ":line-height", :id "nqFY4YkfKFleaf"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553106355014, :text "\"18px", :id "Hg3PqB05iE"}
           }
          }
         }
@@ -11857,32 +12396,6 @@
                        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104117193, :text "[]", :id "5FttsuFJpX"}
                        "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104120185, :text "k", :id "Mt4rd1Euy"}
                        "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104122264, :text "template", :id "ottjiFWAtq"}
-                      }
-                     }
-                    }
-                   }
-                   "n" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1553104713133, :id "WAdPpL9MNj"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104714710, :text "println", :id "WAdPpL9MNjleaf"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553104715290, :id "5fqC0czkSh"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text "parse-by-word", :id "RyeC_cpB6E"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1553104715290, :id "s_B-Ixr3jD"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text ":name", :id "58DcIX6Zpi"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text "template", :id "t3VB-P8hs3"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1553104715290, :id "gBWWeharVP"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text ":filter", :id "-3kMcypjqX"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text "state", :id "u2_ijiadIL"}
-                        }
-                       }
                       }
                      }
                     }

--- a/calcit.edn
+++ b/calcit.edn
@@ -2749,7 +2749,10 @@
                    "j" {
                     :type :expr, :by "B1y7Rc-Zz", :at 1551715706116, :id "dZVnNDUsC"
                     :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104083755, :text "cursor->", :id "IDtOOWMkGz"}
+                     "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104316205, :text ":overview", :id "-EHgIh5BYt"}
                      "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715710184, :text "comp-overview", :id "gJBUfT3zq3"}
+                     "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104089854, :text "states", :id "6UEd3Mb5JD"}
                      "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715771551, :text "templates", :id "EJZ7ko77A"}
                     }
                    }
@@ -11345,6 +11348,7 @@
             "v" {:type :leaf, :id "SkooW9UgxRrb", :text "span", :by "root", :at 1500541010211}
             "x" {:type :leaf, :id "HJ2obqIlgCB-", :text "div", :by "root", :at 1500541010211}
             "y" {:type :leaf, :id "HyaiWqIgxCrZ", :text "button", :by "root", :at 1529343437918}
+            "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104487423, :text "input", :id "yBxH3mUvLE"}
            }
           }
          }
@@ -11403,6 +11407,45 @@
           }
          }
         }
+        "yx" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1553104208615, :id "jh0L_ECW-"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104208926, :text "[]", :id "jh0L_ECW-leaf"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104209541, :text "fuzzy-filter.core", :id "Zuv4c-ZOAi"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104211417, :text ":refer", :id "yqpzEnJLhT"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1553104211639, :id "d5FdsIifM"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104211857, :text "[]", :id "Fm4BjlWEuo"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104216732, :text "parse-by-word", :id "LxHtrcJaFg"}
+           }
+          }
+         }
+        }
+        "yy" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1553104779847, :id "4rNagTw9yb"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104780160, :text "[]", :id "4rNagTw9ybleaf"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104780559, :text "feather.core", :id "EGNEwsivSh"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104781941, :text ":refer", :id "QkFdKd6TDU"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1553104782210, :id "olld56cTps"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104788415, :text "[]", :id "-0zNbzc6IW"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104786737, :text "comp-icon", :id "bKxzGLieBp"}
+           }
+          }
+         }
+        }
+        "yyT" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1553104919108, :id "edZAnm7av-"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104919437, :text "[]", :id "edZAnm7av-leaf"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104921132, :text "clojure.string", :id "RyrNECCWQ"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104921664, :text ":as", :id "s6LSM9OqA6"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104922514, :text "string", :id "Ia_aACIdeT"}
+         }
+        }
        }
       }
      }
@@ -11416,6 +11459,7 @@
        "r" {
         :type :expr, :id "rkOyMqUexRSW", :by nil, :at 1500541010211
         :data {
+         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104093789, :text "states", :id "gLLAhWkRve"}
          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715777370, :text "templates", :id "-KrfLx-gAd"}
         }
        }
@@ -11439,54 +11483,80 @@
              }
             }
            }
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553104304786, :id "zIsyNKvKla"
+            :data {
+             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104306455, :text "state", :id "pbWJnmE1Z5"}
+             "T" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553104095028, :id "25xeCQV66u"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104095424, :text "or", :id "25xeCQV66uleaf"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104097217, :id "NlpHlOe24"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104097914, :text ":data", :id "9TGMZoObK"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104098702, :text "states", :id "YjB3n3_L3J"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104099324, :id "H5KATJbO_U"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104099720, :text "{}", :id "dJ04xTOTew"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104100317, :id "Ul26tfTVmn"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104101810, :text ":filter", :id "Y1MEruaYzg"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104103402, :text "\"", :id "wkRoNJyNy"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
          "T" {
-          :type :expr, :id "r19kz5Uxx0B-", :by nil, :at 1500541010211
+          :type :expr, :by "B1y7Rc-Zz", :at 1553104451159, :id "im0uA3svXb"
           :data {
-           "T" {:type :leaf, :id "HyskGcUlxRSb", :text "list->", :by "B1y7Rc-Zz", :at 1551715981855}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551715666543, :id "xM_lIMSzm"
+           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104452032, :text "div", :id "G_Vm1Jaks2"}
+           "L" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553104452240, :id "RY_9FUXXMB"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715667903, :text "{}", :id "VAyLpmEE9K"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104452621, :text "{}", :id "QVpk9VidDA"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551715724485, :id "SLnT9IjJHD"
+              :type :expr, :by "B1y7Rc-Zz", :at 1553104465283, :id "5aeYhTTCTy"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715725320, :text ":style", :id "z3CsvpKgep"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551715725548, :id "ak_S7ejMB"
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104468131, :text ":style", :id "MYomwuzNX"}
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104461834, :id "3ayguEUGDq"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715727360, :text "merge", :id "SsI6zT8m4Y"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715728965, :text "ui/flex", :id "756NN9Wflm"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "merge", :id "awU8-QD4Dd"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "ui/flex", :id "1gBB1jV01r"}
+                 "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104480205, :text "ui/column", :id "dSVKnrIRQ"}
                  "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551715736090, :id "M3UxrysHNw"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104461834, :id "b5I_2kSIsN"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715736445, :text "{}", :id "lNqQV7IBM"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551715736719, :id "scg3SWPFX8"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715738167, :text ":padding", :id "r5hVo-z_z"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552231706631, :text "\"8px 16px 160px 16px", :id "GsIUjHG8ee"}
-                    }
-                   }
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "{}", :id "xOG8Zo9mZu"}
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551716418524, :id "ajZtUPEZm"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104461834, :id "bwF8ei7UzS"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716420603, :text ":overflow", :id "ajZtUPEZmleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716421388, :text ":auto", :id "y1BDOLkhUP"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text ":overflow", :id "Cf4cPkYCh9"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text ":auto", :id "BebqUwxFcI"}
                     }
                    }
                    "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551716612049, :id "qY4RS8Zaz_"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104461834, :id "3bTy4QbuuL"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716616995, :text ":background-color", :id "qY4RS8Zaz_leaf"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text ":background-color", :id "1_tsgrBX7B"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1551716633025, :id "Go9QtKisu1"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104461834, :id "XzQnpqq6gt"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716633474, :text "hsl", :id "ZAmntnweth"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716633811, :text "0", :id "zaQ5YsSQv"}
-                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716634057, :text "0", :id "0lMgv3yKUj"}
-                       "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716638449, :text "94", :id "sgAezpRgu0"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "hsl", :id "Y3dfFD2SE9"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "0", :id "sl1ssRLjejx"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "0", :id "lwWwJRdMaen"}
+                       "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104461834, :text "94", :id "CKBhwC4AT-8"}
                       }
                      }
                     }
@@ -11499,191 +11569,453 @@
              }
             }
            }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551715983995, :id "fG_qJaJIRr"
+           "P" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553104481383, :id "c0jTH64R5Y"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715986673, :text "->>", :id "fG_qJaJIRrleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715988691, :text "templates", :id "Fn156RLuW_"}
-             "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551715989045, :id "aZ_ORll3Lo"
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104482509, :text "div", :id "c0jTH64R5Yleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553104482718, :id "C0cRV_j0-3"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715990422, :text "map", :id "CfLcpHT-s3"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104483027, :text "{}", :id "9K3JCP_5y"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1551715992359, :id "cO7N51yDW"
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104543449, :id "v1mrTpvL3h"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715991337, :text "fn", :id "QK-Nf3mbp"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104544309, :text ":style", :id "0CVf1VtqLh"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551715994456, :id "nLL2IpRcqZ"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104847246, :id "KKTw58g0g7"
                   :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104848357, :text "merge", :id "azGxX3uzq"}
+                   "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104851074, :text "ui/row-middle", :id "rvOjnpx2vg"}
                    "T" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1551715995907, :id "5a9JnHBnb"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104544537, :id "nW-_8deUP"
                     :data {
-                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715997348, :text "[]", :id "AjK15jVYmI"}
-                     "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715997681, :text "k", :id "ieH-Ziuagc"}
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715994118, :text "template", :id "rmqs0xpWB"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104544866, :text "{}", :id "by7H_NeU7k"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104545185, :id "0dtWdBG9bc"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104546928, :text ":padding", :id "nTMYu7MZUk"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104597170, :text "\"8px 200px 8px 144px", :id "oEhLus5o-2"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104605242, :id "1XdYcjG82x"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104607721, :text ":border-bottom", :id "1XdYcjG82xleaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104613953, :text "\"1px solid #ddd", :id "-5AGnEpPYR"}
+                      }
+                     }
                     }
                    }
                   }
                  }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551716002511, :id "7zLuUZmBlR"
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553104483492, :id "o6ePFqQrg4"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104484337, :text "input", :id "o6ePFqQrg4leaf"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104484925, :id "OEWOrphV1u"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104485279, :text "{}", :id "sx6oHI84j"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104535888, :id "nHrY0F--8T"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716003220, :text "[]", :id "7zLuUZmBlRleaf"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716005280, :text "k", :id "taSSK5xgf"}
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552671832870, :id "ltqAJZ4r4s"
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104536724, :text ":style", :id "Nw38XGA4y"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104538730, :text "ui/input", :id "S_FJfgHxPO"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104624683, :id "R0mCEuEzx"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104628253, :text ":placeholder", :id "R0mCEuEzxleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104682334, :text "\"filter...", :id "14ypqvBB-9"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104632984, :id "cW67g3EJuT"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104633729, :text ":value", :id "cW67g3EJuTleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104633989, :id "lojVrJRIfl"
                     :data {
-                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671833536, :text "let", :id "uI_5sYSasI"}
-                     "L" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552671833718, :id "a63F25QtPS"
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104635259, :text ":filter", :id "SAAMPrS2Or"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104636331, :text "state", :id "dUBCIgOFF"}
+                    }
+                   }
+                  }
+                 }
+                 "x" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104638038, :id "g_Iwv5plLG"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104641034, :text ":on-input", :id "g_Iwv5plLGleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104641352, :id "XlAzpu96Ao"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104641601, :text "fn", :id "TJ3mBkUTRU"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104641975, :id "vxGAyxF-2C"
                       :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104642202, :text "e", :id "ATMocRIL5u"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104642778, :text "d!", :id "uve37cQltR"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104643573, :text "m!", :id "-SV6vEBeW3"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104727422, :id "ryUoVi3arM"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104729794, :text "m!", :id "M3wu36xeG"}
                        "T" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1552671834798, :id "FZUooJ2I7q"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553104644116, :id "B2F1SYPPXA"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671837038, :text "style-container", :id "JVL9MEm3DW"}
-                         "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "lL50Aio7JU"
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104645425, :text "assoc", :id "B2F1SYPPXAleaf"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104647048, :text "state", :id "CAONQdYso"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104651162, :text ":filter", :id "7LvBJ9LWz"}
+                         "v" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553104651798, :id "Hdw7lM-KI"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "{}", :id "LdIqzElfHd"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "XFH3hN3aOt"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":background-color", :id "QryK72gsdl"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "NZdeiEI8tu"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "hsl", :id "n4eDwDHOEA"}
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "PCL-jWP6Wk"}
-                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "urWeROl4xK"}
-                               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "100", :id "ZpPX3Ag6MS"}
-                              }
-                             }
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "dkoFSrgZiS"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":border", :id "cYpHc1d8S7"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "\"1px solid #ddd", :id "s2pX1IabjJ"}
-                            }
-                           }
-                           "x" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "jgWbg9rbVpA"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671903479, :text ":min-width", :id "To4fds_9gIy"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671932876, :id "N9a0Ziyry"
-                              :data {
-                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671935197, :text "or", :id "w-pL4kO8Xw"}
-                               "T" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "2ikB4H4BF2k"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":width", :id "i1S_nwbSmqn"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "BxnBqnHoSuK"}
-                                }
-                               }
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671937746, :text "240", :id "bMkvreDze"}
-                              }
-                             }
-                            }
-                           }
-                           "y" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "sZvPiyvtP04"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671905455, :text ":min-height", :id "6EkiYviXbHO"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671939151, :id "WcpTGos80j"
-                              :data {
-                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671940427, :text "or", :id "xzgsO1FWnO"}
-                               "T" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "bD8Vf0YG-iE"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":height", :id "SoAym9661pn"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "W_rFxbKpT7i"}
-                                }
-                               }
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671941927, :text "60", :id "C_Fzky4HQE"}
-                              }
-                             }
-                            }
-                           }
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104652997, :text ":value", :id "vtpBpK08gm"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104653305, :text "e", :id "oV5Gw1Ol-v"}
                           }
                          }
                         }
                        }
                       }
                      }
-                     "T" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1551716076201, :id "zY5WcqN9Lo"
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "v" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553104747692, :id "6CLfl9j9r"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104749400, :text "=<", :id "6CLfl9j9rleaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104750647, :text "8", :id "wE3JHL6Y3"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104751276, :text "nil", :id "W5fhV5U5O3"}
+              }
+             }
+             "x" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1553104896787, :id "rw4MfKabqe"
+              :data {
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104904910, :text "if-not", :id "zQk-P990XJ"}
+               "L" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104905183, :id "35zhFwYiq-"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104910709, :text "string/blank?", :id "rudZu1iuG1"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104911164, :id "IS2r4wnJwK"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104912993, :text ":filter", :id "Z7dhGFsf8f"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104913638, :text "state", :id "k225zmprBY"}
+                  }
+                 }
+                }
+               }
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104751799, :id "6jTus-uwrz"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104759343, :text "comp-icon", :id "6jTus-uwrzleaf"}
+                 "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104813778, :text ":delete", :id "HBF6EPi_lf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104795135, :id "cJGgIjElp"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104795864, :text "{}", :id "bHposUH9E"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104796212, :id "XlW3covYeJ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104801778, :text ":font-size", :id "Tvq61tFTDj"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104857395, :text "18", :id "oCJMzXZdVk"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104803626, :id "GGg7vKADY"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104804656, :text ":color", :id "GGg7vKADYleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104804967, :id "V7y4vBhs5b"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716017170, :text "div", :id "AGtbz-pnZ"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104806977, :text "hsl", :id "VtH0x7Y7tZ"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104807512, :text "200", :id "6Shq7rk4Du"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104808058, :text "80", :id "-8ZQB4IZd"}
+                       "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104809148, :text "70", :id "OayRfh11V"}
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104887112, :id "Pk2S41p4JE"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104889506, :text ":cursor", :id "Pk2S41p4JEleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104890630, :text ":pointer", :id "kaXkKDn2l"}
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104814643, :id "XvdT6hPYa"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104816240, :text "fn", :id "XvdT6hPYaleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104816533, :id "3mREA2fax"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104818807, :text "e", :id "y9UadWFWuP"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104819366, :text "d!", :id "4EIMgyhLoP"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104820019, :text "m!", :id "OIx_6UPxj"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104822075, :id "Xtfr1FZ7A"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104870439, :text "m!", :id "Xtfr1FZ7Aleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104871232, :id "eOAwtGwe66"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104872317, :text "assoc", :id "86-6-cWEN"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104873082, :text "state", :id "LIEgxcwh4_"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104875775, :text ":filter", :id "AwpkSl7dcZ"}
+                       "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104876121, :text "\"", :id "WO_7uNZWeO"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "T" {
+            :type :expr, :id "r19kz5Uxx0B-", :by nil, :at 1500541010211
+            :data {
+             "T" {:type :leaf, :id "HyskGcUlxRSb", :text "list->", :by "B1y7Rc-Zz", :at 1551715981855}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551715666543, :id "xM_lIMSzm"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715667903, :text "{}", :id "VAyLpmEE9K"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104491953, :id "nqAhH-kWgI"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104493094, :text ":style", :id "Bvc2V-QTf4"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104500438, :id "BQD6sU0FC"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104501441, :text "merge", :id "HUMgWjikQ"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104495721, :text "ui/flex", :id "KjBOiapYmP"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104502293, :id "H6FF9RKL9d"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104502640, :text "{}", :id "Fv_-Nm4t41"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104502868, :id "y5wNzDNDKm"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104504874, :text ":overflow", :id "MKWWm6Z2Ad"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104505959, :text ":auto", :id "ptZMLKD1DW"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104525293, :id "vlw44mtTrZ"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104525293, :text ":padding", :id "C10zde-Yhb"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104525293, :text "\"8px 16px 160px 16px", :id "vKkRfSebzD"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1551715983995, :id "fG_qJaJIRr"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715986673, :text "->>", :id "fG_qJaJIRrleaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715988691, :text "templates", :id "Fn156RLuW_"}
+               "n" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553104112973, :id "SYTALj9AgM"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104114209, :text "filter", :id "LUlpLq1fV"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553104114792, :id "KYt2NO_GRr"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104115751, :text "fn", :id "v7E3DSBRR"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104116485, :id "L4nZWJj65M"
+                    :data {
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104116888, :id "5fCZq5RTg"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104117193, :text "[]", :id "5FttsuFJpX"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104120185, :text "k", :id "Mt4rd1Euy"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104122264, :text "template", :id "ottjiFWAtq"}
+                      }
+                     }
+                    }
+                   }
+                   "n" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104713133, :id "WAdPpL9MNj"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104714710, :text "println", :id "WAdPpL9MNjleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104715290, :id "5fqC0czkSh"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text "parse-by-word", :id "RyeC_cpB6E"}
                        "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1551716017450, :id "VBfSGDuZVX"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553104715290, :id "s_B-Ixr3jD"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716017799, :text "{}", :id "aKeKAw7anI"}
-                         "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1551716452348, :id "3Jt-kMzCF6"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716454887, :text ":style", :id "Gl56RvTsp"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551716517548, :id "c5_DncdQx"
-                            :data {
-                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716519826, :text "merge", :id "TC32rzs-_H"}
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716456113, :text "ui/row", :id "D_30Lbpuf6"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1551716520245, :id "8sw8WvYjSa"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716520569, :text "{}", :id "6zJU1L6Oqa"}
-                               "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1551716520810, :id "mv68AKuBmP"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716522763, :text ":margin", :id "VDqjcppSCc"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716530765, :text "\"16px 0px", :id "1ZRsJeYEI6"}
-                                }
-                               }
-                              }
-                             }
-                            }
-                           }
-                          }
-                         }
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text ":name", :id "58DcIX6Zpi"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text "template", :id "t3VB-P8hs3"}
                         }
                        }
                        "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1551716033050, :id "UZfqENbu49"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553104715290, :id "gBWWeharVP"
                         :data {
-                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716033839, :text "div", :id "FsAlI2pCbR"}
-                         "L" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1551716034080, :id "wi33xLQn3r"
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text ":filter", :id "-3kMcypjqX"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104715290, :text "state", :id "u2_ijiadIL"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1553104250448, :id "rhm6PgjyVG"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104263911, :text ":matches?", :id "XdA5-hMm1"}
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1553104125025, :id "YSabhQ_FL"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104224482, :text "parse-by-word", :id "YSabhQ_FLleaf"}
+                       "b" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553104239697, :id "QrgPad5eT"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104241087, :text ":name", :id "8GELDsCOss"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104242352, :text "template", :id "CxG0cccMe-"}
+                        }
+                       }
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1553104234281, :id "pX8XCq5Wpm"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104236024, :text ":filter", :id "vn7jew2M0"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553104237093, :text "state", :id "Gn1-2z2xuK"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1551715989045, :id "aZ_ORll3Lo"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715990422, :text "map", :id "CfLcpHT-s3"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551715992359, :id "cO7N51yDW"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715991337, :text "fn", :id "QK-Nf3mbp"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1551715994456, :id "nLL2IpRcqZ"
+                    :data {
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1551715995907, :id "5a9JnHBnb"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715997348, :text "[]", :id "AjK15jVYmI"}
+                       "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715997681, :text "k", :id "ieH-Ziuagc"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551715994118, :text "template", :id "rmqs0xpWB"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1551716002511, :id "7zLuUZmBlR"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716003220, :text "[]", :id "7zLuUZmBlRleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716005280, :text "k", :id "taSSK5xgf"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1552671832870, :id "ltqAJZ4r4s"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671833536, :text "let", :id "uI_5sYSasI"}
+                       "L" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1552671833718, :id "a63F25QtPS"
+                        :data {
+                         "T" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1552671834798, :id "FZUooJ2I7q"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716034449, :text "{}", :id "Hde2k9-E-y"}
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671837038, :text "style-container", :id "JVL9MEm3DW"}
                            "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551716035076, :id "Z2AzAW7PT_"
+                            :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "lL50Aio7JU"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716036068, :text ":style", :id "6rGN6kXvK"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "{}", :id "LdIqzElfHd"}
                              "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1551716036287, :id "U9CeaWJM8P"
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "XFH3hN3aOt"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716036621, :text "{}", :id "PzGOkdS5Bh"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":background-color", :id "QryK72gsdl"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1551716037898, :id "RgXN7Ic_SI"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "NZdeiEI8tu"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716042934, :text ":font-family", :id "dnPbkdnI_c"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716049546, :text "ui/font-fancy", :id "6kf_omsVRC"}
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "hsl", :id "n4eDwDHOEA"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "PCL-jWP6Wk"}
+                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "urWeROl4xK"}
+                                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "100", :id "ZpPX3Ag6MS"}
                                 }
                                }
-                               "r" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1551716050741, :id "RgxeSF6Jn"
+                              }
+                             }
+                             "r" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "dkoFSrgZiS"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":border", :id "cYpHc1d8S7"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "\"1px solid #ddd", :id "s2pX1IabjJ"}
+                              }
+                             }
+                             "x" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "jgWbg9rbVpA"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671903479, :text ":min-width", :id "To4fds_9gIy"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671932876, :id "N9a0Ziyry"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716052044, :text ":font-size", :id "RgxeSF6Jnleaf"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716053565, :text "20", :id "-wCBuYRFq1"}
+                                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671935197, :text "or", :id "w-pL4kO8Xw"}
+                                 "T" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "2ikB4H4BF2k"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":width", :id "i1S_nwbSmqn"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "BxnBqnHoSuK"}
+                                  }
+                                 }
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671937746, :text "240", :id "bMkvreDze"}
                                 }
                                }
-                               "v" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1551716473927, :id "m0NbQYecE9"
+                              }
+                             }
+                             "y" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "sZvPiyvtP04"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671905455, :text ":min-height", :id "6EkiYviXbHO"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671939151, :id "WcpTGos80j"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716475610, :text ":min-width", :id "m0NbQYecE9leaf"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716480413, :text "120", :id "HWc96QImRl"}
+                                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671940427, :text "or", :id "xzgsO1FWnO"}
+                                 "T" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "bD8Vf0YG-iE"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":height", :id "SoAym9661pn"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "W_rFxbKpT7i"}
+                                  }
+                                 }
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671941927, :text "60", :id "C_Fzky4HQE"}
                                 }
                                }
                               }
@@ -11692,59 +12024,79 @@
                            }
                           }
                          }
-                         "T" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1551716018872, :id "FKJ7Gs8Ju_"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716019191, :text "<>", :id "FKJ7Gs8Ju_leaf"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551716020349, :id "HcYTPOmY1_"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716022085, :text ":name", :id "Q7RiSZuyBm"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716023841, :text "template", :id "5D_kzTPM9"}
-                            }
-                           }
-                          }
-                         }
                         }
                        }
-                       "v" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1552671438794, :id "qMVmCHtb8Q"
+                       "T" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1551716076201, :id "zY5WcqN9Lo"
                         :data {
-                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671439329, :text "if", :id "qg3cFtX1if"}
-                         "L" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1552671439632, :id "EqyLKbgeo"
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716017170, :text "div", :id "AGtbz-pnZ"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1551716017450, :id "VBfSGDuZVX"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671469750, :text "empty?", :id "z2usqfeQlJ"}
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716017799, :text "{}", :id "aKeKAw7anI"}
                            "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671441622, :id "A7eBofgEbN"
+                            :type :expr, :by "B1y7Rc-Zz", :at 1551716452348, :id "3Jt-kMzCF6"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671441622, :text ":mocks", :id "bDElHWquBS"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671441622, :text "template", :id "4aUmhZ1Uti"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716454887, :text ":style", :id "Gl56RvTsp"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1551716517548, :id "c5_DncdQx"
+                              :data {
+                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716519826, :text "merge", :id "TC32rzs-_H"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716456113, :text "ui/row", :id "D_30Lbpuf6"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1551716520245, :id "8sw8WvYjSa"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716520569, :text "{}", :id "6zJU1L6Oqa"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716520810, :id "mv68AKuBmP"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716522763, :text ":margin", :id "VDqjcppSCc"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716530765, :text "\"16px 0px", :id "1ZRsJeYEI6"}
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
                             }
                            }
                           }
                          }
-                         "P" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1552671534616, :id "A_BC5VI_X"
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1551716033050, :id "UZfqENbu49"
                           :data {
-                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671537935, :text "div", :id "yD_oSsT2_e"}
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716033839, :text "div", :id "FsAlI2pCbR"}
                            "L" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671538131, :id "08MFgceRwU"
+                            :type :expr, :by "B1y7Rc-Zz", :at 1551716034080, :id "wi33xLQn3r"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671538469, :text "{}", :id "c7bBF_97gX"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716034449, :text "{}", :id "Hde2k9-E-y"}
                              "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671538656, :id "V1A3FJdRi0"
+                              :type :expr, :by "B1y7Rc-Zz", :at 1551716035076, :id "Z2AzAW7PT_"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671539405, :text ":style", :id "rOtRzlgME"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716036068, :text ":style", :id "6rGN6kXvK"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671593727, :id "zy3VReua8k"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1551716036287, :id "U9CeaWJM8P"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671594054, :text "{}", :id "dMnlCNw7D"}
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716036621, :text "{}", :id "PzGOkdS5Bh"}
                                  "j" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671594288, :id "vT28G_qVm9"
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716037898, :id "RgXN7Ic_SI"
                                   :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671595371, :text ":padding", :id "UDTsIkrIQQ"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671595676, :text "8", :id "0qaGRXA44w"}
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716042934, :text ":font-family", :id "dnPbkdnI_c"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716049546, :text "ui/font-fancy", :id "6kf_omsVRC"}
+                                  }
+                                 }
+                                 "r" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716050741, :id "RgxeSF6Jn"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716052044, :text ":font-size", :id "RgxeSF6Jnleaf"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716053565, :text "20", :id "-wCBuYRFq1"}
+                                  }
+                                 }
+                                 "v" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716473927, :id "m0NbQYecE9"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716475610, :text ":min-width", :id "m0NbQYecE9leaf"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716480413, :text "120", :id "HWc96QImRl"}
                                   }
                                  }
                                 }
@@ -11754,124 +12106,156 @@
                             }
                            }
                            "T" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671586897, :id "nh_69oXktQ"
+                            :type :expr, :by "B1y7Rc-Zz", :at 1551716018872, :id "FKJ7Gs8Ju_"
                             :data {
-                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671589149, :text "div", :id "gQRQW2DgCB"}
-                             "L" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671589334, :id "Xvgc8TDysQ"
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716019191, :text "<>", :id "FKJ7Gs8Ju_leaf"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1551716020349, :id "HcYTPOmY1_"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671589703, :text "{}", :id "yHSA0oM0j7"}
-                               "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671590221, :id "PhIrHzXbLl"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671591000, :text ":style", :id "dxyq6GJ0qh"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671844535, :text "style-container", :id "g0FV3knzEX"}
-                                }
-                               }
-                              }
-                             }
-                             "T" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "zR6wAN9vlq"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "render-markup", :id "khqdjm8y6f"}
-                               "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "_GhejP4KXW"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":markup", :id "uKb_u6Q8Oh"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "template", :id "3paFH9xjN8"}
-                                }
-                               }
-                               "r" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "v6RkONkA5q"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "{}", :id "znUq2w-J-C"}
-                                 "j" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "lPb6wAopLo"
-                                  :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":data", :id "VU_zvYNRai"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671503729, :text "nil", :id "_21FREGXaT"}
-                                  }
-                                 }
-                                 "r" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "mLrlmozdsZ"
-                                  :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":templates", :id "GZ2epkA3FJ"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "tmpls", :id "ErVqh_iNGoW"}
-                                  }
-                                 }
-                                 "v" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "VxiGJuN0GO6"
-                                  :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":level", :id "VWe8czDBH7w"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "0", :id "qalWQCffVMV"}
-                                  }
-                                 }
-                                 "x" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552720515643, :id "S3LDIAe89D"
-                                  :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720515643, :text ":hide-popup?", :id "unHcI-pRlO"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720515643, :text "true", :id "l4mHXvdSiy"}
-                                  }
-                                 }
-                                }
-                               }
-                               "v" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "aMbA_Pt6ygX"
-                                :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "fn", :id "67IoglCj8gA"}
-                                 "j" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "nHuxzoZZKAj"
-                                  :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "d!", :id "ylLsz-nyaOY"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "op", :id "Qv8wISaODeM"}
-                                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "param", :id "Fd9vNZ_5Y2P"}
-                                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "options", :id "Q3K5OwMreTZ"}
-                                  }
-                                 }
-                                 "r" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "y34Q3QcN4k3"
-                                  :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "println", :id "_dp-LwUwWVG"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "op", :id "kklS7JbS8kt"}
-                                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "param", :id "SS--tRSywzY"}
-                                   "v" {
-                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "ZttleB93V4P"
-                                    :data {
-                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "pr-str", :id "j81N9Tpp5zz"}
-                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "options", :id "UcJ_QSGM3Vc"}
-                                    }
-                                   }
-                                  }
-                                 }
-                                }
-                               }
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716022085, :text ":name", :id "Q7RiSZuyBm"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716023841, :text "template", :id "5D_kzTPM9"}
                               }
                              }
                             }
                            }
                           }
                          }
-                         "T" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1551716065240, :id "6QrovXfzUw"
+                         "v" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1552671438794, :id "qMVmCHtb8Q"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716067192, :text "list->", :id "6QrovXfzUwleaf"}
-                           "b" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551716136972, :id "cvW0nkba6V"
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671439329, :text "if", :id "qg3cFtX1if"}
+                           "L" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1552671439632, :id "EqyLKbgeo"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716136754, :text "{}", :id "p0AdLZbS1h"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671469750, :text "empty?", :id "z2usqfeQlJ"}
                              "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1551716200159, :id "8ehWKMKe1I"
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671441622, :id "A7eBofgEbN"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716201792, :text ":style", :id "ngydXjCUbR"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671441622, :text ":mocks", :id "bDElHWquBS"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671441622, :text "template", :id "4aUmhZ1Uti"}
+                              }
+                             }
+                            }
+                           }
+                           "P" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1552671534616, :id "A_BC5VI_X"
+                            :data {
+                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671537935, :text "div", :id "yD_oSsT2_e"}
+                             "L" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671538131, :id "08MFgceRwU"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671538469, :text "{}", :id "c7bBF_97gX"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1551717169111, :id "hpBBMg_QJ9"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671538656, :id "V1A3FJdRi0"
                                 :data {
-                                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717170004, :text "merge", :id "OuG5yqdJLh"}
-                                 "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717171450, :text "ui/flex", :id "spJ_zMHwx_"}
-                                 "T" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716208753, :id "y371AMFyL"
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671539405, :text ":style", :id "rOtRzlgME"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671593727, :id "zy3VReua8k"
                                   :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716209213, :text "{}", :id "FEnnwwz7lA"}
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671594054, :text "{}", :id "dMnlCNw7D"}
+                                   "j" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671594288, :id "vT28G_qVm9"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671595371, :text ":padding", :id "UDTsIkrIQQ"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671595676, :text "8", :id "0qaGRXA44w"}
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                             "T" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671586897, :id "nh_69oXktQ"
+                              :data {
+                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671589149, :text "div", :id "gQRQW2DgCB"}
+                               "L" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671589334, :id "Xvgc8TDysQ"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671589703, :text "{}", :id "yHSA0oM0j7"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671590221, :id "PhIrHzXbLl"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671591000, :text ":style", :id "dxyq6GJ0qh"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671844535, :text "style-container", :id "g0FV3knzEX"}
+                                  }
+                                 }
+                                }
+                               }
+                               "T" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "zR6wAN9vlq"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "render-markup", :id "khqdjm8y6f"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "_GhejP4KXW"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":markup", :id "uKb_u6Q8Oh"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "template", :id "3paFH9xjN8"}
+                                  }
+                                 }
+                                 "r" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "v6RkONkA5q"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "{}", :id "znUq2w-J-C"}
+                                   "j" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "lPb6wAopLo"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":data", :id "VU_zvYNRai"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671503729, :text "nil", :id "_21FREGXaT"}
+                                    }
+                                   }
+                                   "r" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "mLrlmozdsZ"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":templates", :id "GZ2epkA3FJ"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "tmpls", :id "ErVqh_iNGoW"}
+                                    }
+                                   }
+                                   "v" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "VxiGJuN0GO6"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text ":level", :id "VWe8czDBH7w"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "0", :id "qalWQCffVMV"}
+                                    }
+                                   }
+                                   "x" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552720515643, :id "S3LDIAe89D"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720515643, :text ":hide-popup?", :id "unHcI-pRlO"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720515643, :text "true", :id "l4mHXvdSiy"}
+                                    }
+                                   }
+                                  }
+                                 }
+                                 "v" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "aMbA_Pt6ygX"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "fn", :id "67IoglCj8gA"}
+                                   "j" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "nHuxzoZZKAj"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "d!", :id "ylLsz-nyaOY"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "op", :id "Qv8wISaODeM"}
+                                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "param", :id "Fd9vNZ_5Y2P"}
+                                     "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "options", :id "Q3K5OwMreTZ"}
+                                    }
+                                   }
+                                   "r" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "y34Q3QcN4k3"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "println", :id "_dp-LwUwWVG"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "op", :id "kklS7JbS8kt"}
+                                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "param", :id "SS--tRSywzY"}
+                                     "v" {
+                                      :type :expr, :by "B1y7Rc-Zz", :at 1552671498677, :id "ZttleB93V4P"
+                                      :data {
+                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "pr-str", :id "j81N9Tpp5zz"}
+                                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671498677, :text "options", :id "UcJ_QSGM3Vc"}
+                                      }
+                                     }
+                                    }
+                                   }
                                   }
                                  }
                                 }
@@ -11880,252 +12264,223 @@
                              }
                             }
                            }
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1551716133649, :id "qHPLEZYFn"
+                           "T" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1551716065240, :id "6QrovXfzUw"
                             :data {
-                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716135406, :text "->>", :id "W7o21mZUoW"}
-                             "T" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1551716069540, :id "goK0qh-_U"
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716067192, :text "list->", :id "6QrovXfzUwleaf"}
+                             "b" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1551716136972, :id "cvW0nkba6V"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716192847, :text ":mocks", :id "JNKHls4tO"}
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716124628, :text "template", :id "eyPdZCs2MT"}
-                              }
-                             }
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1551716139388, :id "ED5XzOa_06"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716140052, :text "map", :id "flmqmqSvov"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716136754, :text "{}", :id "p0AdLZbS1h"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1551716140903, :id "Dyf7_TEde-"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1551716200159, :id "8ehWKMKe1I"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716141105, :text "fn", :id "WPU0MonJ5"}
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716201792, :text ":style", :id "ngydXjCUbR"}
                                  "j" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716141780, :id "SKlUQoM-TH"
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1551717169111, :id "hpBBMg_QJ9"
                                   :data {
+                                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717170004, :text "merge", :id "OuG5yqdJLh"}
+                                   "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717171450, :text "ui/flex", :id "spJ_zMHwx_"}
                                    "T" {
-                                    :type :expr, :by "B1y7Rc-Zz", :at 1551716142423, :id "NVqjByPqlP"
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1551716208753, :id "y371AMFyL"
                                     :data {
-                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716142658, :text "[]", :id "Pgmyi5pWM"}
-                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716143020, :text "k", :id "pJ5T4qD_Fi"}
-                                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716144018, :text "mock", :id "BonfRKLLAH"}
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716209213, :text "{}", :id "FEnnwwz7lA"}
                                     }
                                    }
                                   }
                                  }
-                                 "r" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716146601, :id "s_q6wKrvf"
+                                }
+                               }
+                              }
+                             }
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1551716133649, :id "qHPLEZYFn"
+                              :data {
+                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716135406, :text "->>", :id "W7o21mZUoW"}
+                               "T" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1551716069540, :id "goK0qh-_U"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716192847, :text ":mocks", :id "JNKHls4tO"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716124628, :text "template", :id "eyPdZCs2MT"}
+                                }
+                               }
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1551716139388, :id "ED5XzOa_06"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716140052, :text "map", :id "flmqmqSvov"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716140903, :id "Dyf7_TEde-"
                                   :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716147252, :text "[]", :id "s_q6wKrvfleaf"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716149020, :text "k", :id "yWMduoa57"}
-                                   "r" {
-                                    :type :expr, :by "B1y7Rc-Zz", :at 1551716152948, :id "6aymvR4lS"
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716141105, :text "fn", :id "WPU0MonJ5"}
+                                   "j" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1551716141780, :id "SKlUQoM-TH"
                                     :data {
-                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716155207, :text "div", :id "aMvA9-xgA"}
-                                     "j" {
-                                      :type :expr, :by "B1y7Rc-Zz", :at 1551716155491, :id "hnJjJEes9j"
+                                     "T" {
+                                      :type :expr, :by "B1y7Rc-Zz", :at 1551716142423, :id "NVqjByPqlP"
                                       :data {
-                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716156078, :text "{}", :id "BFzUcDaeU2"}
+                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716142658, :text "[]", :id "Pgmyi5pWM"}
+                                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716143020, :text "k", :id "pJ5T4qD_Fi"}
+                                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716144018, :text "mock", :id "BonfRKLLAH"}
+                                      }
+                                     }
+                                    }
+                                   }
+                                   "r" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1551716146601, :id "s_q6wKrvf"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716147252, :text "[]", :id "s_q6wKrvfleaf"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716149020, :text "k", :id "yWMduoa57"}
+                                     "r" {
+                                      :type :expr, :by "B1y7Rc-Zz", :at 1551716152948, :id "6aymvR4lS"
+                                      :data {
+                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716155207, :text "div", :id "aMvA9-xgA"}
                                        "j" {
-                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716228504, :id "v2kfxVXZuJ"
+                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716155491, :id "hnJjJEes9j"
                                         :data {
-                                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716229679, :text ":style", :id "6k_0CMkej"}
-                                         "T" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716246269, :id "rViydGEBob"
+                                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716156078, :text "{}", :id "BFzUcDaeU2"}
+                                         "j" {
+                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716228504, :id "v2kfxVXZuJ"
                                           :data {
-                                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716247900, :text "merge", :id "McEu3sWRx"}
-                                           "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716900019, :text "ui/row", :id "BsVGSIieE"}
+                                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716229679, :text ":style", :id "6k_0CMkej"}
                                            "T" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716226390, :id "90xEMvrU2T"
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716246269, :id "rViydGEBob"
                                             :data {
-                                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716227044, :text "{}", :id "ockNyQbEm"}
+                                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716247900, :text "merge", :id "McEu3sWRx"}
+                                             "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716900019, :text "ui/row", :id "BsVGSIieE"}
                                              "T" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716210985, :id "mnHdck0Ysa"
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716226390, :id "90xEMvrU2T"
                                               :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716213714, :text ":display", :id "8dNIPfBxgG"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716711431, :text ":inline-flex", :id "bp2O8u7VjZ"}
-                                              }
-                                             }
-                                             "r" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716563040, :id "jjDqUVL9G"
-                                              :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716570157, :text ":margin-right", :id "jjDqUVL9Gleaf"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716789563, :text "32", :id "TtA8mccqtH"}
-                                              }
-                                             }
-                                             "x" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716589189, :id "3F2Zd9EkDS"
-                                              :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716590996, :text ":padding", :id "3F2Zd9EkDSleaf"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716591875, :text "8", :id "P1n5KgohPG"}
-                                              }
-                                             }
-                                             "y" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551717079953, :id "2qjSjcL3vs"
-                                              :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717079953, :text ":vertical-align", :id "kCHz3GSVSt"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717079953, :text ":top", :id "iI9VJ2ZkB1"}
-                                              }
-                                             }
-                                            }
-                                           }
-                                          }
-                                         }
-                                        }
-                                       }
-                                      }
-                                     }
-                                     "v" {
-                                      :type :expr, :by "B1y7Rc-Zz", :at 1551716759588, :id "dOYNAWiCJ"
-                                      :data {
-                                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716760309, :text "div", :id "RcL5HKdY3A"}
-                                       "L" {
-                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716760592, :id "xoktNMt-W"
-                                        :data {
-                                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716761336, :text "{}", :id "I-6XTAHysJ"}
-                                         "j" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716761642, :id "C3l_nkpVh"
-                                          :data {
-                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716763103, :text ":style", :id "8gvVUNiPOF"}
-                                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671847000, :text "style-container", :id "nf5a5D7S8F"}
-                                          }
-                                         }
-                                        }
-                                       }
-                                       "T" {
-                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "yCUsAYz7sa"
-                                        :data {
-                                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552194054236, :text "render-markup", :id "CLkOEaD35b"}
-                                         "j" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716363218, :id "ThLzykBhH_"
-                                          :data {
-                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716371716, :text ":markup", :id "o8azV5DOoM"}
-                                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716373747, :text "template", :id "vU-DbQrvbS"}
-                                          }
-                                         }
-                                         "r" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "8FB4ES5nKs"
-                                          :data {
-                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "{}", :id "x5IqUTHYfW"}
-                                           "j" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "Ol5BEnV_Ko"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text ":data", :id "IWjOI9IwjN"}
-                                             "j" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716402824, :id "KwhjU67Bg"
-                                              :data {
-                                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716405051, :text ":data", :id "ArQLKLNGl_"}
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716360773, :text "mock", :id "XV4QFfkLof"}
-                                              }
-                                             }
-                                            }
-                                           }
-                                           "r" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "NIqjeaLFK7"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text ":templates", :id "GrulMVdQIm"}
-                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "tmpls", :id "gQf9XSLXNz"}
-                                            }
-                                           }
-                                           "v" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "fkwzCTImyF"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text ":level", :id "OSNvcXNZx3"}
-                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "0", :id "j0iLaFsj7N"}
-                                            }
-                                           }
-                                           "x" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1552720512046, :id "vX68003LyR"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720512046, :text ":hide-popup?", :id "amyST3Z7Bn"}
-                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720512046, :text "true", :id "AVNnVcYNUa"}
-                                            }
-                                           }
-                                          }
-                                         }
-                                         "v" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "yT69r2XcVT"
-                                          :data {
-                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "fn", :id "43tTZv_CyPs"}
-                                           "j" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "R6XtWH0TS6n"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "d!", :id "GzVSNjvsXv0"}
-                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "op", :id "tW39r3YGqcg"}
-                                             "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193923241, :text "param", :id "l2U6-7lAvX"}
-                                             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193914419, :text "options", :id "aS8NgB8Z_pk"}
-                                            }
-                                           }
-                                           "r" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "qrTtdLTMxNX"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "println", :id "J6VCUmFmVtK"}
-                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "op", :id "j1m6rj19G1J"}
-                                             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193921155, :text "param", :id "9acTweLdJa4"}
-                                             "x" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1552193924659, :id "Ou3wBP_8t"
-                                              :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193925729, :text "pr-str", :id "v70HrLn5F-"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193927445, :text "options", :id "qahGmmCGRU"}
-                                              }
-                                             }
-                                            }
-                                           }
-                                          }
-                                         }
-                                        }
-                                       }
-                                      }
-                                     }
-                                     "x" {
-                                      :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "3900KFPQJ3"
-                                      :data {
-                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "div", :id "tFYS38CJ5X"}
-                                       "j" {
-                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "oyN5WCmeMs"
-                                        :data {
-                                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "{}", :id "7mT1lsSPTy"}
-                                         "j" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "f3DT1uv6-k"
-                                          :data {
-                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text ":style", :id "1-r02MCMwF"}
-                                           "j" {
-                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "BROWcaP7zM"
-                                            :data {
-                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "{}", :id "yvQMkAzdiN"}
-                                             "j" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "u2N93aE1wk"
-                                              :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716864976, :text ":margin-left", :id "8qg67HIaui"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "8", :id "HcjDo6M-i3"}
-                                              }
-                                             }
-                                             "r" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "3Ix74xUzTP"
-                                              :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text ":color", :id "lJbE1rUS25"}
-                                               "j" {
-                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "4bYjyx3eqD"
+                                               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716227044, :text "{}", :id "ockNyQbEm"}
+                                               "T" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716210985, :id "mnHdck0Ysa"
                                                 :data {
-                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "hsl", :id "A8now1Vv7I"}
-                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "0", :id "36zlkDesxAt"}
-                                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "0", :id "EHJy9XUuqsp"}
-                                                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "70", :id "4Py5RrIGyEe"}
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716213714, :text ":display", :id "8dNIPfBxgG"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716711431, :text ":inline-flex", :id "bp2O8u7VjZ"}
+                                                }
+                                               }
+                                               "r" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716563040, :id "jjDqUVL9G"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716570157, :text ":margin-right", :id "jjDqUVL9Gleaf"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716789563, :text "32", :id "TtA8mccqtH"}
+                                                }
+                                               }
+                                               "x" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716589189, :id "3F2Zd9EkDS"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716590996, :text ":padding", :id "3F2Zd9EkDSleaf"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716591875, :text "8", :id "P1n5KgohPG"}
+                                                }
+                                               }
+                                               "y" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551717079953, :id "2qjSjcL3vs"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717079953, :text ":vertical-align", :id "kCHz3GSVSt"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717079953, :text ":top", :id "iI9VJ2ZkB1"}
                                                 }
                                                }
                                               }
                                              }
-                                             "v" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551717024812, :id "cocDGgQSjX"
+                                            }
+                                           }
+                                          }
+                                         }
+                                        }
+                                       }
+                                       "v" {
+                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716759588, :id "dOYNAWiCJ"
+                                        :data {
+                                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716760309, :text "div", :id "RcL5HKdY3A"}
+                                         "L" {
+                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716760592, :id "xoktNMt-W"
+                                          :data {
+                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716761336, :text "{}", :id "I-6XTAHysJ"}
+                                           "j" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716761642, :id "C3l_nkpVh"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716763103, :text ":style", :id "8gvVUNiPOF"}
+                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671847000, :text "style-container", :id "nf5a5D7S8F"}
+                                            }
+                                           }
+                                          }
+                                         }
+                                         "T" {
+                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "yCUsAYz7sa"
+                                          :data {
+                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552194054236, :text "render-markup", :id "CLkOEaD35b"}
+                                           "j" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716363218, :id "ThLzykBhH_"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716371716, :text ":markup", :id "o8azV5DOoM"}
+                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716373747, :text "template", :id "vU-DbQrvbS"}
+                                            }
+                                           }
+                                           "r" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "8FB4ES5nKs"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "{}", :id "x5IqUTHYfW"}
+                                             "j" {
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "Ol5BEnV_Ko"
                                               :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717026910, :text ":font-size", :id "cocDGgQSjXleaf"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717031840, :text "13", :id "VxpOpA-_n0"}
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text ":data", :id "IWjOI9IwjN"}
+                                               "j" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716402824, :id "KwhjU67Bg"
+                                                :data {
+                                                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716405051, :text ":data", :id "ArQLKLNGl_"}
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716360773, :text "mock", :id "XV4QFfkLof"}
+                                                }
+                                               }
+                                              }
+                                             }
+                                             "r" {
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "NIqjeaLFK7"
+                                              :data {
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text ":templates", :id "GrulMVdQIm"}
+                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "tmpls", :id "gQf9XSLXNz"}
+                                              }
+                                             }
+                                             "v" {
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "fkwzCTImyF"
+                                              :data {
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text ":level", :id "OSNvcXNZx3"}
+                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "0", :id "j0iLaFsj7N"}
                                               }
                                              }
                                              "x" {
-                                              :type :expr, :by "B1y7Rc-Zz", :at 1551717034244, :id "eNiN-Ah3c"
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1552720512046, :id "vX68003LyR"
                                               :data {
-                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717035847, :text ":font-family", :id "TFv4wyS2q2"}
-                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717038043, :text "ui/font-fancy", :id "tYE0MqyOKf"}
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720512046, :text ":hide-popup?", :id "amyST3Z7Bn"}
+                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552720512046, :text "true", :id "AVNnVcYNUa"}
+                                              }
+                                             }
+                                            }
+                                           }
+                                           "v" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "yT69r2XcVT"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "fn", :id "43tTZv_CyPs"}
+                                             "j" {
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "R6XtWH0TS6n"
+                                              :data {
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "d!", :id "GzVSNjvsXv0"}
+                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "op", :id "tW39r3YGqcg"}
+                                               "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193923241, :text "param", :id "l2U6-7lAvX"}
+                                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193914419, :text "options", :id "aS8NgB8Z_pk"}
+                                              }
+                                             }
+                                             "r" {
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716331695, :id "qrTtdLTMxNX"
+                                              :data {
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "println", :id "J6VCUmFmVtK"}
+                                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716331695, :text "op", :id "j1m6rj19G1J"}
+                                               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193921155, :text "param", :id "9acTweLdJa4"}
+                                               "x" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1552193924659, :id "Ou3wBP_8t"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193925729, :text "pr-str", :id "v70HrLn5F-"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193927445, :text "options", :id "qahGmmCGRU"}
+                                                }
+                                               }
                                               }
                                              }
                                             }
@@ -12134,15 +12489,75 @@
                                          }
                                         }
                                        }
-                                       "r" {
-                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "e_ARGEr7DZe"
+                                       "x" {
+                                        :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "3900KFPQJ3"
                                         :data {
-                                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "<>", :id "0YYaZUOxoAH"}
+                                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "div", :id "tFYS38CJ5X"}
                                          "j" {
-                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "wBP3NR7qpwc"
+                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "oyN5WCmeMs"
                                           :data {
-                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text ":name", :id "3hXz7ivGmi9"}
-                                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "mock", :id "CzdO2u_6t8l"}
+                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "{}", :id "7mT1lsSPTy"}
+                                           "j" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "f3DT1uv6-k"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text ":style", :id "1-r02MCMwF"}
+                                             "j" {
+                                              :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "BROWcaP7zM"
+                                              :data {
+                                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "{}", :id "yvQMkAzdiN"}
+                                               "j" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "u2N93aE1wk"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716864976, :text ":margin-left", :id "8qg67HIaui"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "8", :id "HcjDo6M-i3"}
+                                                }
+                                               }
+                                               "r" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "3Ix74xUzTP"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text ":color", :id "lJbE1rUS25"}
+                                                 "j" {
+                                                  :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "4bYjyx3eqD"
+                                                  :data {
+                                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "hsl", :id "A8now1Vv7I"}
+                                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "0", :id "36zlkDesxAt"}
+                                                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "0", :id "EHJy9XUuqsp"}
+                                                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "70", :id "4Py5RrIGyEe"}
+                                                  }
+                                                 }
+                                                }
+                                               }
+                                               "v" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551717024812, :id "cocDGgQSjX"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717026910, :text ":font-size", :id "cocDGgQSjXleaf"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717031840, :text "13", :id "VxpOpA-_n0"}
+                                                }
+                                               }
+                                               "x" {
+                                                :type :expr, :by "B1y7Rc-Zz", :at 1551717034244, :id "eNiN-Ah3c"
+                                                :data {
+                                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717035847, :text ":font-family", :id "TFv4wyS2q2"}
+                                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551717038043, :text "ui/font-fancy", :id "tYE0MqyOKf"}
+                                                }
+                                               }
+                                              }
+                                             }
+                                            }
+                                           }
+                                          }
+                                         }
+                                         "r" {
+                                          :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "e_ARGEr7DZe"
+                                          :data {
+                                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "<>", :id "0YYaZUOxoAH"}
+                                           "j" {
+                                            :type :expr, :by "B1y7Rc-Zz", :at 1551716858825, :id "wBP3NR7qpwc"
+                                            :data {
+                                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text ":name", :id "3hXz7ivGmi9"}
+                                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551716858825, :text "mock", :id "CzdO2u_6t8l"}
+                                            }
+                                           }
                                           }
                                          }
                                         }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -3,6 +3,7 @@
  :dependencies [[mvc-works/hsl          "0.1.2"]
                 [mvc-works/shell-page   "0.1.10"]
                 [mvc-works/ws-edn       "0.1.3"]
+                [mvc-works/fuzzy-filter "0.0.6"]
                 [cumulo/recollect       "0.5.0"]
                 [cumulo/reel            "0.1.1"]
                 [cumulo/util            "0.1.6"]

--- a/src/composer/comp/bg_picker.cljs
+++ b/src/composer/comp/bg_picker.cljs
@@ -40,7 +40,8 @@
                                     :width 32,
                                     :height 32,
                                     :margin 4,
-                                    :cursor :pointer}),
+                                    :cursor :pointer,
+                                    :border "1px solid #ddd"}),
                            :on-click (fn [e d! m!] (set-color! (:color color) d!))}
                           (<> (:name color) {:color :white, :font-size 10}))])))))]))))
     (div

--- a/src/composer/comp/container.cljs
+++ b/src/composer/comp/container.cljs
@@ -77,7 +77,7 @@
           :home (cursor-> :workspace comp-workspace states templates settings focus-to)
           :preview
             (cursor-> :preview comp-preview states templates focus-to (:shadows? session))
-          :overview (comp-overview templates)
+          :overview (cursor-> :overview comp-overview states templates)
           :profile (comp-profile (:user store) (:data router))
           :settings (cursor-> :settings comp-settings states settings)
           (<> router))

--- a/src/composer/comp/mock_data.cljs
+++ b/src/composer/comp/mock_data.cljs
@@ -38,9 +38,18 @@
    (=< 40 nil)
    (a
     {:style ui/link,
-     :inner-text "Use this",
+     :inner-text "Use it",
      :on-click (fn [e d! m!]
        (d! :template/use-mock {:template-id template-id, :mock-id (:id mock)}))})
+   (=< 8 nil)
+   (cursor->
+    :fork
+    comp-prompt
+    states
+    {:trigger (a {:style ui/link, :inner-text "Fork"}), :text "Fork with new name:"}
+    (fn [result d! m!]
+      (when-not (string/blank? result)
+        (d! :template/fork-mock {:template-id template-id, :mock-id (:id mock), :name result}))))
    (=< 8 nil)
    (cursor->
     :remove
@@ -111,10 +120,14 @@
               (div
                {:style (merge
                         ui/row-middle
-                        {:cursor :pointer, :padding "0 8px"}
+                        {:cursor :pointer,
+                         :padding "0 8px",
+                         :border-bottom "1px solid #eee",
+                         :line-height "32px",
+                         :height "32px"}
                         (if (= focused-id (:id mock)) {:background-color (hsl 0 0 94)})),
                 :on-click (fn [e d! m!] (d! :session/focus-to {:mock-id (:id mock)}))}
-               (<> (:name mock))
+               (<> (or (:name mock) "-"))
                (=< 8 nil)
                (if (= used-mock (:id mock)) (comp-i :star 14 (hsl 0 80 70))))))))))
   (if-let [mock (get mocks focused-id)]

--- a/src/composer/comp/mock_data.cljs
+++ b/src/composer/comp/mock_data.cljs
@@ -11,80 +11,114 @@
             [respo-alerts.comp.alerts :refer [comp-prompt comp-confirm]]
             [clojure.string :as string]
             [favored-edn.core :refer [write-edn]]
-            [cljs.reader :refer [read-string]]))
+            [cljs.reader :refer [read-string]]
+            [inflow-popup.comp.popup :refer [comp-popup]]))
+
+(def style-code {:font-family ui/font-code, :font-size 12, :line-height "18px"})
+
+(defcomp
+ comp-data-editor
+ (states data on-submit)
+ (let [state (or (:data states) {:draft (write-edn data), :error nil})]
+   (div
+    {:style ui/column}
+    (textarea
+     {:style (merge ui/textarea style-code {:height 240, :width 600}),
+      :placeholder "EDN data",
+      :value (:draft state),
+      :on-input (fn [e d! m!] (m! (assoc state :draft (:value e))))})
+    (div
+     {:style (merge ui/row-parted {:margin-top 8})}
+     (if (some? (:error state))
+       (div
+        {:style {:color :red, :max-width 360, :line-height "20px"}}
+        (<> (:error state) {:color :red}))
+       (span nil))
+     (button
+      {:inner-text "Submit",
+       :style ui/button,
+       :on-click (fn [e d! m!]
+         (try
+          (do (on-submit (read-string (:draft state)) d! m!) (m! nil))
+          (catch js/Error err (.error js/console err) (m! (assoc state :error err)))))})))))
 
 (defcomp
  comp-mock-editor
  (states template-id mock)
- (div
-  {:style (merge ui/flex ui/column)}
-  (div
-   {:style {:padding "4px 8px"}}
-   (cursor->
-    :rename
-    comp-prompt
-    states
-    {:trigger (div
-               {:style ui/row-middle}
-               (<> (:name mock))
-               (=< 8 nil)
-               (comp-i :edit 14 (hsl 200 80 60))),
-     :initial (:name mock)}
-    (fn [result d! m!]
-      (when-not (string/blank? result)
-        (d!
-         :template/rename-mock
-         {:template-id template-id, :mock-id (:id mock), :text result}))))
-   (=< 40 nil)
-   (a
-    {:style ui/link,
-     :inner-text "Use it",
-     :on-click (fn [e d! m!]
-       (d! :template/use-mock {:template-id template-id, :mock-id (:id mock)}))})
-   (=< 8 nil)
-   (cursor->
-    :fork
-    comp-prompt
-    states
-    {:trigger (a {:style ui/link, :inner-text "Fork"}), :text "Fork with new name:"}
-    (fn [result d! m!]
-      (when-not (string/blank? result)
-        (d! :template/fork-mock {:template-id template-id, :mock-id (:id mock), :name result}))))
-   (=< 8 nil)
-   (cursor->
-    :remove
-    comp-confirm
-    states
-    {:trigger (a {:style ui/link, :inner-text "Remove"}), :text "Sure to remove mock data?"}
-    (fn [e d! m!]
-      (d! :template/remove-mock {:template-id template-id, :mock-id (:id mock)}))))
-  (div
-   {:style ui/flex}
-   (cursor->
-    :data
-    comp-prompt
-    states
-    {:trigger (pre
-               {:style (merge
-                        ui/textarea
-                        {:font-family ui/font-code,
-                         :width "100%",
-                         :line-height "20px",
-                         :font-size 13}),
-                :disabled true,
-                :inner-text (write-edn (:data mock))}),
-     :style {:width "100%", :padding "0 8px"},
-     :multiline? true,
-     :input-style {:font-family ui/font-code},
-     :initial (write-edn (:data mock))}
-    (fn [result d! m!]
-      (try
-       (do
-        (let [data (read-string result)]
+ (let [base-op-data {:template-id template-id, :mock-id (:id mock)}]
+   (div
+    {:style (merge ui/flex ui/column)}
+    (div
+     {:style {:padding "4px 8px"}}
+     (cursor->
+      :rename
+      comp-prompt
+      states
+      {:trigger (div
+                 {:style ui/row-middle}
+                 (<> (:name mock))
+                 (=< 8 nil)
+                 (comp-i :edit 14 (hsl 200 80 60))),
+       :initial (:name mock)}
+      (fn [result d! m!]
+        (when-not (string/blank? result)
           (d!
-           :template/update-mock
-           {:template-id template-id, :mock-id (:id mock), :data data})))
-       (catch js/Error err (.error js/console err) (js/alert "Invalid data"))))))))
+           :template/rename-mock
+           {:template-id template-id, :mock-id (:id mock), :text result}))))
+     (=< 40 nil)
+     (a
+      {:style ui/link,
+       :inner-text "Use it",
+       :on-click (fn [e d! m!]
+         (d! :template/use-mock {:template-id template-id, :mock-id (:id mock)}))})
+     (=< 8 nil)
+     (cursor->
+      :fork
+      comp-prompt
+      states
+      {:trigger (a {:style ui/link, :inner-text "Fork"}), :text "Fork with new name:"}
+      (fn [result d! m!]
+        (when-not (string/blank? result)
+          (d!
+           :template/fork-mock
+           {:template-id template-id, :mock-id (:id mock), :name result}))))
+     (=< 8 nil)
+     (cursor->
+      :remove
+      comp-confirm
+      states
+      {:trigger (a {:style ui/link, :inner-text "Remove"}),
+       :text "Sure to remove mock data?"}
+      (fn [e d! m!]
+        (d! :template/remove-mock {:template-id template-id, :mock-id (:id mock)}))))
+    (div
+     {:style {:padding "0px 8px", :max-height 320, :overflow :auto}}
+     (pre
+      {:style (merge
+               style-code
+               {:width "100%",
+                :margin 0,
+                :background-color (hsl 0 0 96),
+                :padding "4px 8px"}),
+       :disabled true,
+       :inner-text (write-edn (:data mock))}))
+    (div
+     {:style {:padding 8}}
+     (cursor->
+      :edit
+      comp-popup
+      states
+      {:trigger (a {:style ui/link, :inner-text "Edit data"}), :style nil}
+      (fn [on-toggle]
+        (cursor->
+         :edit-data
+         comp-data-editor
+         states
+         (:data mock)
+         (fn [data d! m!]
+           (println "edit data" data)
+           (d! :template/update-mock (merge base-op-data {:data data}))
+           (on-toggle m!)))))))))
 
 (defcomp
  comp-mock-data

--- a/src/composer/comp/overflow.cljs
+++ b/src/composer/comp/overflow.cljs
@@ -3,70 +3,90 @@
   (:require [hsl.core :refer [hsl]]
             [composer.schema :as schema]
             [respo-ui.core :as ui]
-            [respo.core :refer [defcomp list-> <> span div button]]
+            [respo.core :refer [defcomp list-> <> span div button input]]
             [respo.comp.space :refer [=<]]
             [composer.config :as config]
             [composer.util :refer [neaten-templates]]
-            [composer.core :refer [render-markup]]))
+            [composer.core :refer [render-markup]]
+            [fuzzy-filter.core :refer [parse-by-word]]
+            [feather.core :refer [comp-icon]]
+            [clojure.string :as string]))
 
 (defcomp
  comp-overview
- (templates)
- (let [tmpls (neaten-templates templates)]
-   (list->
-    {:style (merge
-             ui/flex
-             {:padding "8px 16px 160px 16px",
-              :overflow :auto,
-              :background-color (hsl 0 0 94)})}
-    (->> templates
-         (map
-          (fn [[k template]]
-            [k
-             (let [style-container {:background-color (hsl 0 0 100),
-                                    :border "1px solid #ddd",
-                                    :min-width (or (:width template) 240),
-                                    :min-height (or (:height template) 60)}]
-               (div
-                {:style (merge ui/row {:margin "16px 0px"})}
+ (states templates)
+ (let [tmpls (neaten-templates templates), state (or (:data states) {:filter ""})]
+   (div
+    {:style (merge ui/flex ui/column {:overflow :auto, :background-color (hsl 0 0 94)})}
+    (div
+     {:style (merge
+              ui/row-middle
+              {:padding "8px 200px 8px 144px", :border-bottom "1px solid #ddd"})}
+     (input
+      {:style ui/input,
+       :placeholder "filter...",
+       :value (:filter state),
+       :on-input (fn [e d! m!] (m! (assoc state :filter (:value e))))})
+     (=< 8 nil)
+     (if-not (string/blank? (:filter state))
+       (comp-icon
+        :delete
+        {:font-size 18, :color (hsl 200 80 70), :cursor :pointer}
+        (fn [e d! m!] (m! (assoc state :filter ""))))))
+    (list->
+     {:style (merge ui/flex {:overflow :auto, :padding "8px 16px 160px 16px"})}
+     (->> templates
+          (filter
+           (fn [[k template]]
+             (println (parse-by-word (:name template) (:filter state)))
+             (:matches? (parse-by-word (:name template) (:filter state)))))
+          (map
+           (fn [[k template]]
+             [k
+              (let [style-container {:background-color (hsl 0 0 100),
+                                     :border "1px solid #ddd",
+                                     :min-width (or (:width template) 240),
+                                     :min-height (or (:height template) 60)}]
                 (div
-                 {:style {:font-family ui/font-fancy, :font-size 20, :min-width 120}}
-                 (<> (:name template)))
-                (if (empty? (:mocks template))
-                  (div
-                   {:style {:padding 8}}
+                 {:style (merge ui/row {:margin "16px 0px"})}
+                 (div
+                  {:style {:font-family ui/font-fancy, :font-size 20, :min-width 120}}
+                  (<> (:name template)))
+                 (if (empty? (:mocks template))
                    (div
-                    {:style style-container}
-                    (render-markup
-                     (:markup template)
-                     {:data nil, :templates tmpls, :level 0, :hide-popup? true}
-                     (fn [d! op param options] (println op param (pr-str options))))))
-                  (list->
-                   {:style (merge ui/flex {})}
-                   (->> (:mocks template)
-                        (map
-                         (fn [[k mock]]
-                           [k
-                            (div
-                             {:style (merge
-                                      ui/row
-                                      {:display :inline-flex,
-                                       :margin-right 32,
-                                       :padding 8,
-                                       :vertical-align :top})}
+                    {:style {:padding 8}}
+                    (div
+                     {:style style-container}
+                     (render-markup
+                      (:markup template)
+                      {:data nil, :templates tmpls, :level 0, :hide-popup? true}
+                      (fn [d! op param options] (println op param (pr-str options))))))
+                   (list->
+                    {:style (merge ui/flex {})}
+                    (->> (:mocks template)
+                         (map
+                          (fn [[k mock]]
+                            [k
                              (div
-                              {:style style-container}
-                              (render-markup
-                               (:markup template)
-                               {:data (:data mock),
-                                :templates tmpls,
-                                :level 0,
-                                :hide-popup? true}
-                               (fn [d! op param options]
-                                 (println op param (pr-str options)))))
-                             (div
-                              {:style {:margin-left 8,
-                                       :color (hsl 0 0 70),
-                                       :font-size 13,
-                                       :font-family ui/font-fancy}}
-                              (<> (:name mock))))])))))))]))))))
+                              {:style (merge
+                                       ui/row
+                                       {:display :inline-flex,
+                                        :margin-right 32,
+                                        :padding 8,
+                                        :vertical-align :top})}
+                              (div
+                               {:style style-container}
+                               (render-markup
+                                (:markup template)
+                                {:data (:data mock),
+                                 :templates tmpls,
+                                 :level 0,
+                                 :hide-popup? true}
+                                (fn [d! op param options]
+                                  (println op param (pr-str options)))))
+                              (div
+                               {:style {:margin-left 8,
+                                        :color (hsl 0 0 70),
+                                        :font-size 13,
+                                        :font-family ui/font-fancy}}
+                               (<> (:name mock))))])))))))])))))))

--- a/src/composer/comp/overflow.cljs
+++ b/src/composer/comp/overflow.cljs
@@ -37,9 +37,7 @@
      {:style (merge ui/flex {:overflow :auto, :padding "8px 16px 160px 16px"})}
      (->> templates
           (filter
-           (fn [[k template]]
-             (println (parse-by-word (:name template) (:filter state)))
-             (:matches? (parse-by-word (:name template) (:filter state)))))
+           (fn [[k template]] (:matches? (parse-by-word (:name template) (:filter state)))))
           (map
            (fn [[k template]]
              [k

--- a/src/composer/config.cljs
+++ b/src/composer/config.cljs
@@ -18,7 +18,7 @@
 
 (def site
   {:port 6011,
-   :title "Composer App",
+   :title "Composer",
    :icon "http://cdn.tiye.me/logo/respo.png",
    :dev-ui "http://localhost:8100/main.css",
    :release-ui "http://cdn.tiye.me/favored-fonts/main.css",

--- a/src/composer/core.cljs
+++ b/src/composer/core.cljs
@@ -298,11 +298,11 @@
   (let [props (:props markup)
         width (read-token (get props "width") (:data context))
         height (read-token (get props "height") (:data context))]
-    (=< width height)))
+    (if (and (nil? width) (nil? height)) (comp-invalid "<Space nil>" props) (=< width height))))
 
 (defn render-text [markup context]
   (let [props (:props markup), value (read-token (get props "value") (:data context))]
-    (<> value (merge (style-presets (:presets markup)) (:style markup)))))
+    (<> (or value "TEXT") (merge (style-presets (:presets markup)) (:style markup)))))
 
 (def style-unknown {"font-size" 12, "color" :red})
 
@@ -333,13 +333,13 @@
                  :value (nil? value)
                  nil (nil? value)
                  (nil? value))]
-    (if (not= (count child-pair) 2)
-      (do
-       (js/console.warn "<Some> requires 2 children, but got" (count child-pair))
-       (comp-invalid "<Bad some>" props))
-      (if result
-        (render-markup (first child-pair) context on-action)
-        (render-markup (last child-pair) context on-action)))))
+    (cond
+      (not= (count child-pair) 2) (comp-invalid "<Some wants 2 children>" props)
+      (nil? (get props "value")) (comp-invalid "<Some requires a value>" props)
+      :else
+        (if result
+          (render-markup (first child-pair) context on-action)
+          (render-markup (last child-pair) context on-action)))))
 
 (defn render-popup [markup context on-action]
   (let [props (:props markup)

--- a/src/composer/core.cljs
+++ b/src/composer/core.cljs
@@ -328,7 +328,7 @@
         child-pair (->> (:children markup) (sort-by first) (vals))
         result (case kind
                  :list (empty? value)
-                 :boolean (= value false)
+                 :boolean (or (= value false) (nil? value))
                  :string (string/blank? value)
                  :value (nil? value)
                  nil (nil? value)

--- a/src/composer/updater.cljs
+++ b/src/composer/updater.cljs
@@ -32,6 +32,7 @@
             :template/update-mock template/update-mock
             :template/remove-mock template/remove-mock
             :template/rename-mock template/rename-mock
+            :template/fork-mock template/fork-mock
             :template/use-mock template/use-mock
             :template/append-markup template/append-markup
             :template/prepend-markup template/prepend-markup

--- a/src/composer/updater/template.cljs
+++ b/src/composer/updater/template.cljs
@@ -56,6 +56,19 @@
                        :mock-pointer mock-id})]
     (assoc-in db [:templates op-id] new-template)))
 
+(defn fork-mock [db op-data sid op-id op-time]
+  (let [template-id (:template-id op-data)
+        mock-id (:mock-id op-data)
+        new-name (:name op-data)]
+    (update-in
+     db
+     [:templates template-id :mocks]
+     (fn [mocks]
+       (let [old-mock (get mocks mock-id)
+             new-mock (merge old-mock {:id op-id, :name new-name})]
+         (println "mocks" mocks new-mock)
+         (assoc mocks op-id new-mock))))))
+
 (defn iter-merge-children [container picked-id xs]
   (if (empty? xs)
     container

--- a/src/composer/updater/template.cljs
+++ b/src/composer/updater/template.cljs
@@ -44,8 +44,16 @@
 
 (defn create-template [db op-data sid op-id op-time]
   (let [markup-id "system"
+        mock-id "base"
         base-markup (merge schema/markup {:id markup-id, :type :box, :layout :row})
-        new-template (merge schema/template {:id op-id, :name op-data, :markup base-markup})]
+        new-mock (merge schema/mock {:id mock-id, :name "base", :data {}})
+        new-template (merge
+                      schema/template
+                      {:id op-id,
+                       :name op-data,
+                       :markup base-markup,
+                       :mocks {mock-id new-mock},
+                       :mock-pointer mock-id})]
     (assoc-in db [:templates op-id] new-template)))
 
 (defn iter-merge-children [container picked-id xs]


### PR DESCRIPTION
See commits for details. The most significant changes is to refactor the editor of mocking data. Now it looks like:

![image](https://user-images.githubusercontent.com/449224/54709755-0c419600-4b81-11e9-88ce-696be134710c.png)
![image](https://user-images.githubusercontent.com/449224/54709766-15326780-4b81-11e9-89c2-5d54ed4cfedf.png)
