### PR TITLE
Sort templates with drag/drop

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 
 calcit.edn -diff linguist-generated
-yarn.lock -diff
+yarn.lock -diff linguist-generated

--- a/calcit.edn
+++ b/calcit.edn
@@ -13391,6 +13391,38 @@
                  }
                 }
                }
+               "p" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554831170787, :id "if9Um4qo1"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831172967, :text "sort-by", :id "if9Um4qo1leaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831173598, :id "UmrXCiRIP"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831174642, :text "fn", :id "_EsQKEKvxT"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831174891, :id "uZvmg005k-"
+                    :data {
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554831178205, :id "Z3k5ZjISsf"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831175337, :text "[]", :id "4hhjS3fEFZ"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831179180, :text "k", :id "Y3t3XWE57N"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831180732, :text "template", :id "tX-srIp7-8"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831181602, :id "FnWbqhYg2"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831183295, :text ":sort-key", :id "FnWbqhYg2leaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831184520, :text "template", :id "yTVlEHdI7"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
                "r" {
                 :type :expr, :by "B1y7Rc-Zz", :at 1551715989045, :id "aZ_ORll3Lo"
                 :data {
@@ -19987,6 +20019,38 @@
                 :data {
                  "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548571239648, :text "->>", :id "-6GJ2tOuiZ"}
                  "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548571239648, :text "templates", :id "KWExf33bZv"}
+                 "n" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831120151, :id "aLM8qCYQS-"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831125699, :text "sort-by", :id "rKztLCa3P"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831126179, :id "CohrK_4i9s"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831127573, :text "fn", :id "GzpZP2efVT"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554831127847, :id "dUDfmPw-Yz"
+                      :data {
+                       "T" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554831129402, :id "6CYhkgdOh"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831129698, :text "[]", :id "DaHljBKwfV"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831131648, :text "k", :id "DvT-E9gpR_"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831132693, :text "template", :id "-TlCEm35cu"}
+                        }
+                       }
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554831133590, :id "xKSV3UwKO"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831137317, :text ":sort-key", :id "xKSV3UwKOleaf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831138554, :text "template", :id "tmG-d1qDI"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
                  "r" {
                   :type :expr, :by "B1y7Rc-Zz", :at 1548571239648, :id "Hp-LZH4B2B"
                   :data {
@@ -20161,6 +20225,175 @@
                            }
                           }
                          }
+                         "t" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554829673946, :id "RDuXNAqUjM"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829676730, :text ":draggable", :id "RDuXNAqUjMleaf"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829677341, :text "true", :id "aUZY0-WqoU"}
+                          }
+                         }
+                         "u" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554829833050, :id "LpHii2sEQ"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829839057, :text ":on-dragstart", :id "LpHii2sEQleaf"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554829841017, :id "7fH4HxHVEj"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829843248, :text "fn", :id "klQPFMlfp"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554829843612, :id "jb4p0kSTl"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829849655, :text "e", :id "vycnyYPMSt"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829850594, :text "d!", :id "MG4-Xm-ZYa"}
+                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829851835, :text "m!", :id "nv48-OgK-E"}
+                              }
+                             }
+                             "v" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554830050712, :id "sfXZ26T3r"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830055186, :text "->", :id "sfXZ26T3rleaf"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830056823, :text "e", :id "sK25-eVy2i"}
+                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830057679, :text ":event", :id "6LeimZEj4c"}
+                               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830060026, :text ".-dataTransfer", :id "r48_45nbcH"}
+                               "x" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1554830061698, :id "iBk3jeAR6"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830067342, :text ".setData", :id "GC3ww499y"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830069037, :text "\"text", :id "-8nJcjl3_V"}
+                                 "r" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1554830071830, :id "SGgX53d5K0"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830073068, :text ":id", :id "06lksTpMeh"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830074195, :text "template", :id "4AQDY109SO"}
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                         "uT" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554829875228, :id "4KUNUDYmNH"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829879538, :text ":on-dragover", :id "4KUNUDYmNHleaf"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554829881248, :id "AuCiB6viFo"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829881921, :text "fn", :id "VvKPPAzyW"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554829882307, :id "ekIhhprwHH"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829882546, :text "e", :id "7IhPHoxArv"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829884179, :text "d!", :id "agcXxAeio3"}
+                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829884809, :text "m!", :id "RvkfkClKsN"}
+                              }
+                             }
+                             "r" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554829885328, :id "1-z2z7s5Vj"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829899745, :text ".preventDefault", :id "1-z2z7s5Vjleaf"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1554829900273, :id "dxYdAEaECs"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829900273, :text ":event", :id "Ga_tYLhVNW"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829900273, :text "e", :id "qd6K6Z8acH"}
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                         "uj" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554829904104, :id "tDRqo5wPeY"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829906662, :text ":on-drop", :id "tDRqo5wPeYleaf"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554829910370, :id "gvynzWuOB9"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829910685, :text "fn", :id "4mtJ_KSVL"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554829911473, :id "FEwvq3OJiY"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829911707, :text "e", :id "2M5UrnY7qk"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829912413, :text "d!", :id "MkMv6Fmvz5"}
+                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829913170, :text "m!", :id "GOhs9CdPt"}
+                              }
+                             }
+                             "v" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554830079190, :id "4k-x0Qv2Ua"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830081573, :text "let", :id "N_qmpmgZdX"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1554830081841, :id "4icbNhYDlC"
+                                :data {
+                                 "T" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1554830082173, :id "WlEJp6n8Ij"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830084049, :text "drag-id", :id "_yRi9gNN2b"}
+                                   "j" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1554830084352, :id "3XWyjIhr9D"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830089217, :text "->", :id "sSltYKjxmG"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830089686, :text "e", :id "bkVhurVYtI"}
+                                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830092702, :text ":event", :id "TBZI-MyMuo"}
+                                     "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830094385, :text ".-dataTransfer", :id "Iq0r8AJ5Cg"}
+                                     "x" {
+                                      :type :expr, :by "B1y7Rc-Zz", :at 1554830096146, :id "uQzqZpkVMh"
+                                      :data {
+                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830097713, :text ".getData", :id "uOsl8FsXT"}
+                                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830098770, :text "\"text", :id "dUV5bUrvqy"}
+                                      }
+                                     }
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
+                               "r" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1554830105473, :id "O7tTEwcJvY"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830693389, :text "d!", :id "f4DfylxvJX"}
+                                 "d" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830698306, :text ":template/move-order", :id "rObD3222Q"}
+                                 "n" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1554830699606, :id "OhHq_RPOK"
+                                  :data {
+                                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830700201, :text "{}", :id "r_c-Wy-k04"}
+                                   "T" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1554830701365, :id "70qicTorK5"
+                                    :data {
+                                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830707651, :text ":from", :id "g4j83-c0A"}
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830110987, :text "drag-id", :id "f9-qSj_Cd"}
+                                    }
+                                   }
+                                   "j" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1554830708657, :id "rgqaSYemq"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830709244, :text ":to", :id "rgqaSYemqleaf"}
+                                     "j" {
+                                      :type :expr, :by "B1y7Rc-Zz", :at 1554830713972, :id "G1xKq6m1zq"
+                                      :data {
+                                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830713972, :text ":id", :id "B-m0pt-Bwr"}
+                                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830713972, :text "template", :id "QlsnBrPXYn"}
+                                      }
+                                     }
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
                         }
                        }
                        "r" {
@@ -20172,6 +20405,54 @@
                           :data {
                            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548571239648, :text ":name", :id "11GTNRb1Z-_"}
                            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548571239648, :text "template", :id "KWyrkeODnaE"}
+                          }
+                         }
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830279857, :id "-tMKafY9ST"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830280356, :text "<>", :id "-tMKafY9STleaf"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554830280927, :id "U4z20qYWPq"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830283043, :text ":sort-key", :id "vWkyega-u"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830284228, :text "template", :id "DFmXnEGo4W"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554830284924, :id "KtJq8Bb8t5"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830285252, :text "{}", :id "Xmtj92Xs4"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554830285439, :id "JgFRHP9qSi"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830286868, :text ":color", :id "QRR0ikgSxw"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554830287491, :id "v3iO_k--Ej"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830287942, :text "hsl", :id "Ojme0no_ED"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830288480, :text "0", :id "rp2MOslrB-"}
+                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830288794, :text "0", :id "8RCBTC4Tc"}
+                               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831285512, :text "90", :id "FugGLRiQ-4"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554830290044, :id "w2Qrlw1A0a"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830293102, :text ":font-size", :id "w2Qrlw1A0aleaf"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830422084, :text "12", :id "wUaHaMNPgd"}
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554830412048, :id "cUerwapCD2"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830414664, :text ":margin-left", :id "cUerwapCD2leaf"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830419788, :text "4", :id "d0tpskN5_x"}
+                            }
+                           }
                           }
                          }
                         }
@@ -30566,6 +30847,13 @@
            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551549235765, :text "400", :id "mxpiVNHHoB"}
           }
          }
+         "yT" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1554829572519, :id "RA6rci4x1"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829575439, :text ":sort-key", :id "RA6rci4x1leaf"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554829576219, :text "nil", :id "TqOx5lhEg"}
+          }
+         }
         }
        }
       }
@@ -33205,6 +33493,13 @@
                 :data {
                  "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551631582936, :text ":template/mark-saved", :id "XcRxjQ9mwleaf"}
                  "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551631587360, :text "template/mark-saved", :id "64ocUysS8"}
+                }
+               }
+               "yuyyyb" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554830627914, :id "gulr1iMG8o"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830662706, :text ":template/move-order", :id "gulr1iMG8oleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830667537, :text "template/move-order", :id "58YHEzAA3x"}
                 }
                }
                "yuyyyj" {
@@ -36065,6 +36360,277 @@
           :data {
            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551631738114, :text ":templates", :id "pvRBeg-Ya"}
            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551631738519, :text "db", :id "_2JeMSMUp4"}
+          }
+         }
+        }
+       }
+      }
+     }
+     "move-order" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1554830669396, :id "VnN7O7FQQT"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830669396, :text "defn", :id "zH6lBemFob"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830669396, :text "move-order", :id "WSmzajQgke"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1554830676843, :id "BIybFLPRyO"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830676843, :text "db", :id "iJMQR58aiX"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830676843, :text "op-data", :id "M4bA_NFm__"}
+         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830676843, :text "sid", :id "zwIYNyIj0U"}
+         "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830676843, :text "op-id", :id "-qJXeX_NGV"}
+         "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830676843, :text "op-time", :id "v5THv0H6ks"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1554830722575, :id "mTc81Zs9U"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830723024, :text "let", :id "mTc81Zs9Uleaf"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1554830723199, :id "yQvEelTXdz"
+          :data {
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554830723536, :id "XgGhSAVFt"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830725171, :text "from-id", :id "OVtWAVj5qz"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1554830725773, :id "F8gYQqT4H"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830727350, :text ":from", :id "yTw9dQ9P6r"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830728872, :text "op-data", :id "VDkC_e0lMP"}
+              }
+             }
+            }
+           }
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554830730286, :id "a2WfsgO8tI"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830875507, :text "to-id", :id "a2WfsgO8tIleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1554830731120, :id "V9X4tv9djK"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830731526, :text ":to", :id "Ak8qS5Vj6v"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830732914, :text "op-data", :id "J-G7ZUTfQp"}
+              }
+             }
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1554830828327, :id "9LdO0ZWjnV"
+          :data {
+           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830828903, :text "if", :id "VcXQYexfi"}
+           "L" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554830829152, :id "dQUMGZh4u1"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830830903, :text "=", :id "4shDqONolS"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830878151, :text "from-id", :id "Eq0lT_zDFj"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830879624, :text "to-id", :id "myinUxEYA"}
+            }
+           }
+           "P" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830834352, :text "db", :id "ZmRLKw6hAN"}
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554830740440, :id "DJ40tKidG"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830741411, :text "update", :id "DJ40tKidGleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830742510, :text "db", :id "HbE96c1kk"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830748519, :text ":templates", :id "fqa3P8OEa"}
+             "v" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1554830748955, :id "ANolEPexvV"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830749267, :text "fn", :id "mzN8sE8BTi"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554830749533, :id "5nwBw9m6E"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830750831, :text "templates", :id "SV3sdPmOUk"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554830764290, :id "MdqSBDrbF"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830764753, :text "let", :id "MdqSBDrbFleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554830764984, :id "x_aXBtDkFu"
+                  :data {
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554830765136, :id "IadbhLi1um"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830771422, :text "sort-dict", :id "C3rXNB1JhU"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554830772117, :id "NxhJrHu_ox"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830773584, :text "->>", :id "Lgo_FWnLs"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830784794, :text "templates", :id "KpENGewkf"}
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830785109, :id "KBK02f2hNB"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830785775, :text "map", :id "n83EQn3T16"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554830786085, :id "P8-st2Q0i8"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830786826, :text "fn", :id "nvyO0o57La"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554830787710, :id "ROdVA5xG6"
+                            :data {
+                             "T" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554830794185, :id "2NyBUC7_B"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830794436, :text "[]", :id "qiozej8Ltb"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830796841, :text "k", :id "Sqs_PUyxT"}
+                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830798525, :text "template", :id "i7Kze6Nwhk"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1554830800796, :id "qqd2gG9s5G"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830801158, :text "[]", :id "qqd2gG9s5Gleaf"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1554830802059, :id "BSChWDCu8c"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830805356, :text ":sort-key", :id "9vHmJC6nzl"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830809339, :text "template", :id "dfJvnghrZ"}
+                              }
+                             }
+                             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830811705, :text "k", :id "crBaHWrcK4"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830814854, :id "D9cvC14Xup"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830815432, :text "into", :id "D9cvC14Xupleaf"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554830815729, :id "nEPA8Kmzj1"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830816083, :text "{}", :id "lGXX_vyJo"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554830851556, :id "XVpGoEVit"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830853520, :text "from-key", :id "XVpGoEVitleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554830856655, :id "dfMgkEtKS"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830863983, :text "get-in", :id "A3Z7Obmwr"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830865151, :text "templates", :id "nwZyJMNkpz"}
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830865377, :id "az38dklEPA"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830865574, :text "[]", :id "t7NbhUApdM"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830883367, :text "from-id", :id "aUG0vIIWky"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830915971, :text ":sort-key", :id "F6D_C7eoc"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554830851556, :id "RmtFOdtPQ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830893173, :text "to-key", :id "XVpGoEVitleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554830856655, :id "dfMgkEtKS"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830863983, :text "get-in", :id "A3Z7Obmwr"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830865151, :text "templates", :id "nwZyJMNkpz"}
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830865377, :id "az38dklEPA"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830865574, :text "[]", :id "t7NbhUApdM"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830896224, :text "to-id", :id "aUG0vIIWky"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830940409, :text ":sort-key", :id "F6D_C7eoc"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554830942049, :id "0xn5KazdVf"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830944313, :text "next-key", :id "0xn5KazdVfleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554830945447, :id "6Kc4Vqhgh-"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830967176, :text "case", :id "Wkn_oMKbZ"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830967902, :id "sfaVX3YmJ"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830968835, :text "compare", :id "tqE8wUA7kw"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830972814, :text "from-key", :id "vVGpdQ3kJx"}
+                         "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830975224, :text "to-key", :id "2UaGvlyVL"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830976856, :id "5T3icGbac"
+                        :data {
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830986841, :text "-1", :id "8Zk3UK9SG"}
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554831002746, :id "wG6N7shE1d"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831024115, :text "key-after", :id "Jo7ZfacjD"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831027291, :text "sort-dict", :id "0yq2roF6V"}
+                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831029433, :text "to-key", :id "VRZpLuMpw"}
+                          }
+                         }
+                        }
+                       }
+                       "v" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1554830978518, :id "bFt0Y1EZ-"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554830979622, :text "1", :id "bFt0Y1EZ-leaf"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1554831031735, :id "Tp2oCu8T1m"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831034736, :text "key-before", :id "roUiluMSll"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831031735, :text "sort-dict", :id "Lz9yLM8KGM"}
+                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831031735, :text "to-key", :id "9GXQU6E-l3"}
+                          }
+                         }
+                        }
+                       }
+                       "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831064585, :text "to-key", :id "SojYHJdbx3leaf"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554830817602, :id "JkgyukMR5"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831070135, :text "assoc-in", :id "JkgyukMR5leaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831073609, :text "templates", :id "a-x0Y7BbF1"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831074613, :id "YPgG_sx0X"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831074852, :text "[]", :id "s64tRLawZY"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831077145, :text "from-id", :id "MsD-TcEnoN"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831080124, :text ":sort-key", :id "T1G8LRW5V"}
+                    }
+                   }
+                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831083104, :text "next-key", :id "7RL605rnwP"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
           }
          }
         }

--- a/calcit.edn
+++ b/calcit.edn
@@ -36001,53 +36001,136 @@
              }
             }
            }
-           "T" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548570246459, :id "g6fJfIpx4F"
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554831404603, :id "WEMMm0eVX"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570251873, :text "new-template", :id "l9Lpr1jB-m"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831407635, :text "sort-dict", :id "WEMMm0eVXleaf"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548570253017, :id "GS80Mu9Oao"
+              :type :expr, :by "B1y7Rc-Zz", :at 1554831410213, :id "oBGjrbF393"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570255435, :text "merge", :id "MTYvdTuSe"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570259964, :text "schema/template", :id "x50T30FR_t"}
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548570292514, :id "gIMzwkpwJG"
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831415408, :text "->>", :id "YTyyuRae5"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554831415792, :id "xZW9vqdFJq"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570292840, :text "{}", :id "wSO3zl6um"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831417514, :text ":templates", :id "UIvI0gpdS"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831418856, :text "db", :id "RLdHoiPPd"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554831420378, :id "e33Poczjf"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831421135, :text "map", :id "e33Poczjfleaf"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548570293043, :id "QQgXX-IM-C"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831423223, :id "dGoyJtKAZH"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570293518, :text ":id", :id "rEPJFDqcld"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570295311, :text "op-id", :id "g-O0JQtjeL"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831423542, :text "fn", :id "WjbL0l4jH"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831423879, :id "OP4b7d3gQe"
+                    :data {
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554831424258, :id "o2D2RvgAaL"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831425743, :text "[]", :id "Xpy-NwODcz"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831426319, :text "k", :id "3gO8DvasYx"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831428561, :text "template", :id "6fos0Y6HW"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831430695, :id "PDHCRvRlN"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831435756, :text "[]", :id "PDHCRvRlNleaf"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554831438815, :id "i8LgBIFaO"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831441011, :text ":sort-key", :id "nGkUPBkrIJ"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831442195, :text "template", :id "DFpiWCvm7l"}
+                      }
+                     }
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831443066, :text "k", :id "ZTyABdiHj"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554831444846, :id "yyy5rIIx4y"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831445494, :text "into", :id "yyy5rIIx4yleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831445812, :id "BcHPxE78Xs"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831446140, :text "{}", :id "iJozgIA1c"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554831452359, :id "8DvlSyq-Of"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831454784, :text "next-key", :id "8DvlSyq-Ofleaf"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1554831456586, :id "vczolYatu"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831462994, :text "key-prepend", :id "r-f8kunbhQ"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831467022, :text "sort-dict", :id "aLtWCgET6"}
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "ecBTM4SA3M"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "new-template", :id "K4oBqyEbuB"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "SJiSAUl-24"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "merge", :id "3dUao8uPkb"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "schema/template", :id "KjB4H-we6s"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "yt2ZEZhq4t"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "{}", :id "hWaZ2a61gU"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "Doy7pLENUX"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text ":id", :id "a97IiQD0Zn"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "op-id", :id "NQLQXUWg2O"}
                   }
                  }
                  "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548570295930, :id "rh8r1gswgI"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "xMd91QzsPV"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570296605, :text ":name", :id "rh8r1gswgIleaf"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570297884, :text "op-data", :id "EOYy5TUL_9"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text ":name", :id "Qn7yW-_lcZ"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "op-data", :id "MgG58b7fUw"}
                   }
                  }
                  "v" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548570299354, :id "j6fewrUByd"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "BQY8_5G3LM0"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570310109, :text ":markup", :id "j6fewrUBydleaf"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548570395756, :text "base-markup", :id "Zqv32u4Y5f"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text ":markup", :id "Yaabnwyj9ET"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "base-markup", :id "ukyeUKj9UzI"}
                   }
                  }
                  "x" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1553102884868, :id "ZVqnkKWA3S"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "kHyAzN7qmwY"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102887858, :text ":mocks", :id "ZVqnkKWA3Sleaf"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text ":mocks", :id "4Z4SxOSDKkt"}
                    "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1553102888537, :id "CfI8BgYRu"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "BSwxBYfvFWi"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102890327, :text "{}", :id "R1cU5SwGkM"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "{}", :id "DZ2zOAWxYh5"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1553102890628, :id "PhUlUVY7I"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "TeOBcHJM5lo"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102916136, :text "mock-id", :id "AyXBnkBXGM"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102918786, :text "new-mock", :id "pKHX1bp4N3"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "mock-id", :id "u6OKJDQ1cKv"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "new-mock", :id "0P3OplVomcI"}
                       }
                      }
                     }
@@ -36055,10 +36138,17 @@
                   }
                  }
                  "y" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1553102946299, :id "VpW4O3pcgA"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831473241, :id "U5EcMurLIEg"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102946299, :text ":mock-pointer", :id "t_XdV-lnj2"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553102989367, :text "mock-id", :id "6QkM11Qxc_"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text ":mock-pointer", :id "snXRlBiqMpF"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831473241, :text "mock-id", :id "rWHRrHyjpXu"}
+                  }
+                 }
+                 "yT" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554831476622, :id "G8Vu9-k-p"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831477960, :text ":sort-key", :id "G8Vu9-k-pleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554831479019, :text "next-key", :id "EXUK00JWwu"}
                   }
                  }
                 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.2",
-    "latest-version": "^5.0.0",
+    "latest-version": "^5.1.0",
     "md5": "^2.2.1",
     "randomcolor": "^0.5.4",
     "shortid": "^2.2.14",
@@ -34,10 +34,10 @@
     "ws": "^6.2.1"
   },
   "devDependencies": {
-    "copy-text-to-clipboard": "^2.0.0",
+    "copy-text-to-clipboard": "^2.1.0",
     "feather-icons": "^4.21.0",
     "http-server": "^0.11.1",
-    "shadow-cljs": "^2.8.26",
-    "source-map-support": "^0.5.11"
+    "shadow-cljs": "^2.8.29",
+    "source-map-support": "^0.5.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@respo/composer-app",
-  "version": "0.1.5-a1",
+  "version": "0.1.5-a2",
   "description": "Composer app creator for Respo",
   "main": "index.js",
   "bin": {

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,7 +6,7 @@
                 [mvc-works/fuzzy-filter "0.0.6"]
                 [cumulo/recollect       "0.5.0"]
                 [cumulo/reel            "0.1.1"]
-                [cumulo/util            "0.1.6"]
+                [cumulo/util            "0.1.7"]
                 [respo                  "0.10.11"]
                 [respo/ui               "0.3.10"]
                 [respo/alerts           "0.3.11"]

--- a/src/composer/comp/overflow.cljs
+++ b/src/composer/comp/overflow.cljs
@@ -38,6 +38,7 @@
      (->> templates
           (filter
            (fn [[k template]] (:matches? (parse-by-word (:name template) (:filter state)))))
+          (sort-by (fn [[k template]] (:sort-key template)))
           (map
            (fn [[k template]]
              [k

--- a/src/composer/comp/templates_list.cljs
+++ b/src/composer/comp/templates_list.cljs
@@ -33,6 +33,7 @@
       (list->
        {}
        (->> templates
+            (sort-by (fn [[k template]] (:sort-key template)))
             (map-val
              (fn [template]
                (div
@@ -46,5 +47,15 @@
                  :on-click (fn [e d! m!]
                    (d!
                     :session/focus-to
-                    {:template-id (:id template), :path [], :mock-id nil}))}
-                (<> (:name template)))))))))))
+                    {:template-id (:id template), :path [], :mock-id nil})),
+                 :draggable true,
+                 :on-dragstart (fn [e d! m!]
+                   (-> e :event .-dataTransfer (.setData "text" (:id template)))),
+                 :on-dragover (fn [e d! m!] (.preventDefault (:event e))),
+                 :on-drop (fn [e d! m!]
+                   (let [drag-id (-> e :event .-dataTransfer (.getData "text"))]
+                     (d! :template/move-order {:from drag-id, :to (:id template)})))}
+                (<> (:name template))
+                (<>
+                 (:sort-key template)
+                 {:color (hsl 0 0 90), :font-size 12, :margin-left 4}))))))))))

--- a/src/composer/schema.cljs
+++ b/src/composer/schema.cljs
@@ -28,7 +28,8 @@
    :mock-pointer nil,
    :markup (do markup nil),
    :width 400,
-   :height 400})
+   :height 400,
+   :sort-key nil})
 
 (def user {:name nil, :id nil, :nickname nil, :avatar nil, :password nil})
 

--- a/src/composer/updater.cljs
+++ b/src/composer/updater.cljs
@@ -51,6 +51,7 @@
             :template/node-attrs template/update-node-attrs
             :template/set-preview-sizes template/set-preview-sizes
             :template/mark-saved template/mark-saved
+            :template/move-order template/move-order
             :settings/add-color settings/add-color
             :settings/remove-color settings/remove-color
             :settings/update-color settings/update-color

--- a/src/composer/updater/template.cljs
+++ b/src/composer/updater/template.cljs
@@ -75,6 +75,25 @@
 
 (defn mark-saved [db op-data sid op-id op-time] (assoc db :saved-templates (:templates db)))
 
+(defn move-order [db op-data sid op-id op-time]
+  (let [from-id (:from op-data), to-id (:to op-data)]
+    (if (= from-id to-id)
+      db
+      (update
+       db
+       :templates
+       (fn [templates]
+         (let [sort-dict (->> templates
+                              (map (fn [[k template]] [(:sort-key template) k]))
+                              (into {}))
+               from-key (get-in templates [from-id :sort-key])
+               to-key (get-in templates [to-id :sort-key])
+               next-key (case (compare from-key to-key)
+                          -1 (key-after sort-dict to-key)
+                          1 (key-before sort-dict to-key)
+                          to-key)]
+           (assoc-in templates [from-id :sort-key] next-key)))))))
+
 (defn prepend-markup [db op-data sid op-id op-time]
   (let [template-id (:template-id op-data), focused-path (:path op-data)]
     (update-in

--- a/src/composer/updater/template.cljs
+++ b/src/composer/updater/template.cljs
@@ -46,13 +46,18 @@
   (let [mock-id "base"
         base-markup (merge schema/markup {:type :box, :layout :row})
         new-mock (merge schema/mock {:id mock-id, :name "base", :data {}})
+        sort-dict (->> (:templates db)
+                       (map (fn [[k template]] [(:sort-key template) k]))
+                       (into {}))
+        next-key (key-prepend sort-dict)
         new-template (merge
                       schema/template
                       {:id op-id,
                        :name op-data,
                        :markup base-markup,
                        :mocks {mock-id new-mock},
-                       :mock-pointer mock-id})]
+                       :mock-pointer mock-id,
+                       :sort-key next-key})]
     (assoc-in db [:templates op-id] new-template)))
 
 (defn fork-mock [db op-data sid op-id op-time]

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,10 +220,10 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-copy-text-to-clipboard@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.0.0.tgz#4c37fbdb9caa1783c530cd2a180fa8386ae2f1ed"
-  integrity sha512-j42oPYmrNnXhX3kO7znpvfbTgITpnEYS6gWZ0QIRSgp323jbcbryabQYREfIDLi7fOBkRUgIDl6XcSyTvLLbiQ==
+copy-text-to-clipboard@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.1.0.tgz#e222433ba3ec4b1ac5610725f94149160f4723e7"
+  integrity sha512-rxjlVPoTzuKQXem9rdIHSc6xo8TcvqmVZoItxvhMaI1/9MOSNEaee86CpMgv+QVul2Q5v/DkXfOOVwDJxF7KsA==
 
 core-js@^2.5.3:
   version "2.5.7"
@@ -559,12 +559,12 @@ keyv@^3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
-latest-version@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.0.0.tgz#04bc651abd4b921c6a78879db52cbb140dbd818f"
-  integrity sha512-6iCsjOzw7o6Ebe0xh6h7PhfRLIeh52i+xzXVo114tQEvAEVVrzCRIxUWQzflhhYWvF7acxyqok7EFrKD9qScoQ==
+latest-version@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
+  integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
   dependencies:
-    package-json "^6.1.0"
+    package-json "^6.3.0"
 
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
@@ -712,13 +712,13 @@ p-cancelable@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
-package-json@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-6.1.0.tgz#d6f9516e0f8b16ee5c00b7d49f001a665b0c15d2"
-  integrity sha512-TCE9JWb3IU1XMy/d9j3lwLJFF8UUfO7tiXminR3OhtsEm6147k+IFwQ3gAu2VqLZmFvcnOoIKUwOVteUmKwW4Q==
+package-json@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-6.3.0.tgz#5ed793418b8322af7abfb985a19a20c2f40c2fb0"
+  integrity sha512-XO7WS3EEXd48vmW633Y97Mh9xuENFiOevI9G+ExfTG/k6xuY9cBd3fxkAoDMSEsNZXasaVJIJ1rD/n7GMf18bA==
   dependencies:
     got "^9.6.0"
-    registry-auth-token "^3.3.2"
+    registry-auth-token "^3.4.0"
     registry-url "^5.0.0"
     semver "^5.6.0"
 
@@ -875,10 +875,10 @@ readline-sync@^1.4.7:
   resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.7.tgz#001bfdd4c06110c3c084c63bf7c6a56022213f30"
   integrity sha1-ABv91MBhEMPAhMY798alYCIhPzA=
 
-registry-auth-token@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
-  integrity sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==
+registry-auth-token@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
+  integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
   dependencies:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
@@ -938,10 +938,10 @@ shadow-cljs-jar@1.3.0:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.0.tgz#e25c4fa57c0b405096250884b164c112654a06a3"
   integrity sha512-KReNVgFVM2ZPPGCP8rsCPqtlee/+SwXyoeEqbAXBO7jlpoNnNee2x4fiRg/Pr/vXGEkV/Ez5l4qdNSU1Na+1Jg==
 
-shadow-cljs@^2.8.26:
-  version "2.8.26"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.26.tgz#de21e689055c987041a2265f587d029596a18e91"
-  integrity sha512-RMPgVHxPI/JVoZkyOHhYcp/koPyy8k1J9Po8j9LtYWqimrsS3zmEJ+t0nKKqib845m6RkAX5INZPAqUZ7xQ6wQ==
+shadow-cljs@^2.8.29:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.29.tgz#725a575f102228583dd07a23890324e718c23020"
+  integrity sha512-2QsUiy2HVv6jHT/vVbu6yWyRtHBaa0AhTqp1aLj77WkP9WOFAdYpOv3y/8fIp6ffVD1C3q7s2CQCaxZD6SvcGw==
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"
@@ -965,10 +965,10 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.11:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.11.tgz#efac2ce0800355d026326a0ca23e162aeac9a4e2"
-  integrity sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==
+source-map-support@^0.5.12:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
Each template is assigned a `:sort-key` for ordering. Drag/drop would modify the key with `bisection-key`. The `:sort-key`s are displayed in tiny fonts for debugging purpose.

![image](https://user-images.githubusercontent.com/449224/55822393-17f5fc00-5b32-11e9-8680-354afcc47eb5.png)

Upgrade package to `0.1.5-a2` to try the example. Old snapshots need to migrate before sorting.