### PR TITLE
support expression in styles; release 0.1.6-a2

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -1016,71 +1016,6 @@
      :data {}
     }
    }
-   "composer.codegen" {
-    :ns {
-     :type :expr, :by "B1y7Rc-Zz", :at 1549728574345, :id "4NxHqYk0sw"
-     :data {
-      "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728574345, :text "ns", :id "Jm0wPVgu-q"}
-      "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728574345, :text "composer.codegen", :id "uYxu2dMEgO"}
-      "r" {
-       :type :expr, :by "B1y7Rc-Zz", :at 1549728978505, :id "aAAq9DogwQ"
-       :data {
-        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728979352, :text ":require", :id "5VJyG85Tc7"}
-        "j" {
-         :type :expr, :by "B1y7Rc-Zz", :at 1549728980133, :id "dSIEMj__6v"
-         :data {
-          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728980958, :text "[]", :id "NgfzfWJ11"}
-          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728983228, :text "clojure.string", :id "-kupiEdgLv"}
-          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728983651, :text ":as", :id "nnP3kN022j"}
-          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549728985926, :text "string", :id "Zd1t9FnlwQ"}
-         }
-        }
-        "r" {
-         :type :expr, :by "B1y7Rc-Zz", :at 1549729020926, :id "-0LG8ojR-b"
-         :data {
-          "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729026883, :text "[]", :id "YFa34-buI"}
-          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729025711, :text "favored-edn.core", :id "-0LG8ojR-bleaf"}
-          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729031205, :text ":refer", :id "1u1ejb1Pk"}
-          "r" {
-           :type :expr, :by "B1y7Rc-Zz", :at 1549729031474, :id "Ag01yrmxKI"
-           :data {
-            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729032324, :text "[]", :id "ETxEEG2cVq"}
-            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729034489, :text "write-edn", :id "fzVZTHYttr"}
-           }
-          }
-         }
-        }
-       }
-      }
-      "v" {
-       :type :expr, :by "B1y7Rc-Zz", :at 1549729004517, :id "deB_O4WsmX"
-       :data {
-        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729004517, :text ":require-macros", :id "DlM6euhC8B"}
-        "j" {
-         :type :expr, :by "B1y7Rc-Zz", :at 1549729004517, :id "DFciILkoWK"
-         :data {
-          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729004517, :text "[]", :id "_hpbwEL63_"}
-          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729004517, :text "clojure.core.strint", :id "AdJJYHyC1F"}
-          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729004517, :text ":refer", :id "U3EF4ol9G"}
-          "v" {
-           :type :expr, :by "B1y7Rc-Zz", :at 1549729004517, :id "8SwLtqohf-"
-           :data {
-            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729004517, :text "[]", :id "vryYsGTJnL"}
-            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549729004517, :text "<<", :id "6rmL6Py5RM"}
-           }
-          }
-         }
-        }
-       }
-      }
-     }
-    }
-    :defs {}
-    :proc {
-     :type :expr, :by "B1y7Rc-Zz", :at 1549728574345, :id "2v_LIUsYcJ"
-     :data {}
-    }
-   }
    "composer.comp.bg-picker" {
     :ns {
      :type :expr, :by "B1y7Rc-Zz", :at 1549209460389, :id "dbut4Da60_"
@@ -24730,63 +24665,69 @@
         }
        }
        "v" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "ZsL3I2MS5oi8"
+        :type :expr, :by "B1y7Rc-Zz", :at 1555432892715, :id "YSEM0flBM2"
         :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "case", :id "X5cCul6gfDU0"}
-         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "layout", :id "sbQHDislrrBn"}
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "sZjKHUf8Vd8A"
+         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432893807, :text "use-string-keys", :id "moD7Wuwx0K"}
+         "T" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "ZsL3I2MS5oi8"
           :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row", :id "5zrqjh8WAPLf"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row", :id "y6pNyoyoffW5"}
-          }
-         }
-         "v" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "1JqrwkAASmwX"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row-center", :id "Vvpk_8zlKkNG"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row-center", :id "4_HKbIr0jjN_"}
-          }
-         }
-         "x" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "gCtb590T5UY1"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":center", :id "Di4lsgVtTvXS"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/center", :id "FjMLug-oIUs4"}
-          }
-         }
-         "y" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "XFGvB0N-l2Yu"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row-middle", :id "iP4W0_TLo9yw"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row-middle", :id "O9ushgBou9FX"}
-          }
-         }
-         "yT" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6Swu6CMSfmjD"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row-parted", :id "ynprBlMfiPzy"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row-parted", :id "nfwSY5iAm1Va"}
-          }
-         }
-         "yj" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "atuC9WFFnRSC"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":column", :id "k5VZEuGpOKRt"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/column", :id "AP_rvMTHoZlB"}
-          }
-         }
-         "yr" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "zE_RYW0cwRkd"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":column-parted", :id "V8f6QYFc3k1X"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/column-parted", :id "QQEq6oYVnusC"}
-          }
-         }
-         "yv" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "XvnM8c1tdvd1"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "kxvbQrSBPq-j"}
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "case", :id "X5cCul6gfDU0"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "layout", :id "sbQHDislrrBn"}
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "sZjKHUf8Vd8A"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row", :id "5zrqjh8WAPLf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row", :id "y6pNyoyoffW5"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "1JqrwkAASmwX"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row-center", :id "Vvpk_8zlKkNG"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row-center", :id "4_HKbIr0jjN_"}
+            }
+           }
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "gCtb590T5UY1"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":center", :id "Di4lsgVtTvXS"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/center", :id "FjMLug-oIUs4"}
+            }
+           }
+           "y" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "XFGvB0N-l2Yu"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row-middle", :id "iP4W0_TLo9yw"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row-middle", :id "O9ushgBou9FX"}
+            }
+           }
+           "yT" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6Swu6CMSfmjD"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":row-parted", :id "ynprBlMfiPzy"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/row-parted", :id "nfwSY5iAm1Va"}
+            }
+           }
+           "yj" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "atuC9WFFnRSC"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":column", :id "k5VZEuGpOKRt"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/column", :id "AP_rvMTHoZlB"}
+            }
+           }
+           "yr" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "zE_RYW0cwRkd"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":column-parted", :id "V8f6QYFc3k1X"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/column-parted", :id "QQEq6oYVnusC"}
+            }
+           }
+           "yv" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "XvnM8c1tdvd1"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "kxvbQrSBPq-j"}
+            }
+           }
           }
          }
         }
@@ -24805,189 +24746,177 @@
         }
        }
        "v" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Y7_GjmXdXTR6"
+        :type :expr, :by "B1y7Rc-Zz", :at 1555432872602, :id "KcVQfM51r"
         :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "case", :id "96F-j-5LxLvl"}
-         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "preset", :id "wtx4HcjznWsN"}
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "ymihTaU2wfKj"
+         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432873712, :text "use-string-keys", :id "OqFyQ6INGI"}
+         "T" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Y7_GjmXdXTR6"
           :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":flex", :id "UdYdXM0O5zrz"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/flex", :id "B8LK12DhzhNF"}
-          }
-         }
-         "t" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "1pAdEW-nuT"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884541950, :text ":expand", :id "UdYdXM0O5zrz"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226447962, :id "bvqc9RDzc"
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "case", :id "96F-j-5LxLvl"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "preset", :id "wtx4HcjznWsN"}
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "ymihTaU2wfKj"
             :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226449295, :text "merge", :id "aVjZOYmwke"}
-             "T" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1554884590075, :id "zxESitQqWm"
-              :data {
-               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884590888, :text "use-string-keys", :id "ofb23DSTg"}
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/flex", :id "B8LK12DhzhNF"}
-              }
-             }
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":flex", :id "UdYdXM0O5zrz"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/flex", :id "B8LK12DhzhNF"}
+            }
+           }
+           "t" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "1pAdEW-nuT"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884541950, :text ":expand", :id "UdYdXM0O5zrz"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1553226450112, :id "T4_Rec97Pc"
+              :type :expr, :by "B1y7Rc-Zz", :at 1553226447962, :id "bvqc9RDzc"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226451118, :text "{}", :id "yeTok4T0X_"}
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226449295, :text "merge", :id "aVjZOYmwke"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/flex", :id "B8LK12DhzhNF"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1553226451464, :id "79UqHfMJQx"
+                :type :expr, :by "B1y7Rc-Zz", :at 1553226450112, :id "T4_Rec97Pc"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884545040, :text "\"scroll", :id "4jHs4sdkHU"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226458144, :text ":auto", :id "tdr_wwl_a"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226451118, :text "{}", :id "yeTok4T0X_"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1553226451464, :id "79UqHfMJQx"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884545040, :text "\"scroll", :id "4jHs4sdkHU"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226458144, :text ":auto", :id "tdr_wwl_a"}
+                  }
+                 }
                 }
                }
               }
              }
             }
            }
-          }
-         }
-         "v" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "gqBhW6xmDk5Z"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884540209, :text ":font-code", :id "DM7DkzCzki3x"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "MN9JMw229MhU"
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "gqBhW6xmDk5Z"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "9Kvwd1IAgNTs"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884540209, :text ":font-code", :id "DM7DkzCzki3x"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nI1K-kBF7jn4"
+              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "MN9JMw229MhU"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884547110, :text "\"font-family", :id "ekrI7F9SzZwE"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-code", :id "N84KYhxPKNeE"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "9Kvwd1IAgNTs"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nI1K-kBF7jn4"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884547110, :text "\"font-family", :id "ekrI7F9SzZwE"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-code", :id "N84KYhxPKNeE"}
+                }
+               }
               }
              }
             }
            }
-          }
-         }
-         "x" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Xp5IPp31wXrF"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":font-fancy", :id "SH-ou6H6ajr1"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "jtU8UGL3xxaN"
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Xp5IPp31wXrF"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "n4K487R4PZQH"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":font-fancy", :id "SH-ou6H6ajr1"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "9nWn_dcaDJm4"
+              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "jtU8UGL3xxaN"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884548849, :text "\"font-family", :id "_55sXn_l-TXW"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-fancy", :id "brUiVKUGOOUa"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "n4K487R4PZQH"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "9nWn_dcaDJm4"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884548849, :text "\"font-family", :id "_55sXn_l-TXW"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-fancy", :id "brUiVKUGOOUa"}
+                }
+               }
               }
              }
             }
            }
-          }
-         }
-         "y" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6MAyAbJ9hfgK"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":font-normal", :id "MpvVQWfS1k4M"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Y6gdrvbMi0eX"
+           "y" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6MAyAbJ9hfgK"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "GLwOOVw4mmaz"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":font-normal", :id "MpvVQWfS1k4M"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "lFmSQkSVjJFS"
+              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Y6gdrvbMi0eX"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884550874, :text "\"font-family", :id "pua3jdVE0L8F"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-normal", :id "n3aIn9Wf6X9r"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "GLwOOVw4mmaz"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "lFmSQkSVjJFS"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884550874, :text "\"font-family", :id "pua3jdVE0L8F"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-normal", :id "n3aIn9Wf6X9r"}
+                }
+               }
               }
              }
             }
            }
-          }
-         }
-         "yT" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nZUaXRQp7QPP"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":fullscreen", :id "BlPN0fHpP7T3"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1554884571342, :id "N0ZcNVwM1r"
+           "yT" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nZUaXRQp7QPP"
             :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884572013, :text "use-string-keys", :id "gu_s4MLwq"}
-             "T" {:type :leaf, :by "root", :at 1554145367055, :text "ui/fullscreen", :id "g92aEDs1R"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":fullscreen", :id "BlPN0fHpP7T3"}
+             "j" {:type :leaf, :by "root", :at 1554145367055, :text "ui/fullscreen", :id "g92aEDs1R"}
             }
            }
-          }
-         }
-         "yj" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "lbsgpD40ziLg"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":scroll", :id "iKxGxm0Wj8mq"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "vrYwIWQbS07e"
+           "yj" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "lbsgpD40ziLg"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "ip0KllJWwhBE"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":scroll", :id "iKxGxm0Wj8mq"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "QnssNa6bGoVe"
+              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "vrYwIWQbS07e"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884553866, :text "\"overflow", :id "V8AdjOskIu2E"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":auto", :id "bHzqPsuZzYWv"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "ip0KllJWwhBE"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "QnssNa6bGoVe"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884553866, :text "\"overflow", :id "V8AdjOskIu2E"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":auto", :id "bHzqPsuZzYWv"}
+                }
+               }
               }
              }
             }
            }
-          }
-         }
-         "yn" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1553226462778, :id "1oT1P9Ox0"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226463819, :text ":global", :id "1oT1P9Ox0leaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1554884566727, :id "VEhZ4Tp5lc"
+           "yn" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226462778, :id "1oT1P9Ox0"
             :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884567660, :text "use-string-keys", :id "9kYTyPWiuR"}
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226468571, :text "ui/global", :id "yCRX7LIsr"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226463819, :text ":global", :id "1oT1P9Ox0leaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226468571, :text "ui/global", :id "yCRX7LIsr"}
             }
            }
-          }
-         }
-         "yp" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1553226472544, :id "W0PEMx4hI"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226479029, :text ":base-padding", :id "W0PEMx4hIleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226479579, :id "rYnxOHIPH"
+           "yp" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226472544, :id "W0PEMx4hI"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226480007, :text "{}", :id "uJpHJIZGhG"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226479029, :text ":base-padding", :id "W0PEMx4hIleaf"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1553226480347, :id "C86kGbQCqP"
+              :type :expr, :by "B1y7Rc-Zz", :at 1553226479579, :id "rYnxOHIPH"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884555722, :text "\"padding", :id "yScQuC7RdY"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226486003, :text "\"4px 8px", :id "coPY1eqVK4"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226480007, :text "{}", :id "uJpHJIZGhG"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1553226480347, :id "C86kGbQCqP"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884555722, :text "\"padding", :id "yScQuC7RdY"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226486003, :text "\"4px 8px", :id "coPY1eqVK4"}
+                }
+               }
               }
              }
             }
            }
-          }
-         }
-         "yr" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "JyUnLB9EQZTo"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "do", :id "-Z5DC16XEE-9"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "wgd6_zQIYDgh"
+           "yr" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "JyUnLB9EQZTo"
             :data {
-             "T" {:type :leaf, :by "root", :at 1554146828480, :text "js/console.warn", :id "YS_EkR8kT02L"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "do", :id "-Z5DC16XEE-9"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "i5kj3dFn-d4E"
+              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "wgd6_zQIYDgh"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "str", :id "_oLymaIsxRd_"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"Unknown preset: ", :id "ioeBGXjme4Of"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "preset", :id "8jAr3BfJzU0K"}
+               "T" {:type :leaf, :by "root", :at 1554146828480, :text "js/console.warn", :id "YS_EkR8kT02L"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "i5kj3dFn-d4E"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "str", :id "_oLymaIsxRd_"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"Unknown preset: ", :id "ioeBGXjme4Of"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "preset", :id "8jAr3BfJzU0K"}
+                }
+               }
               }
              }
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "nil", :id "Y0ExIHLib5hN"}
             }
            }
-           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "nil", :id "Y0ExIHLib5hN"}
           }
          }
         }
@@ -25087,6 +25016,79 @@
                }
               }
              }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "read-styles" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1555432947202, :id "QrtfPWOPXw"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432947202, :text "defn", :id "w7uslYcoSX"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432947202, :text "read-styles", :id "BvSKtBCT-r"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555432947202, :id "pLJt29Zig8"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432950681, :text "style", :id "TAv-89vTJ2"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432951790, :text "data", :id "InyoMap0IZ"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555432953036, :id "IwPZSAGoT"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432953749, :text "->>", :id "IwPZSAGoTleaf"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432954539, :text "style", :id "9OiGUnRwaR"}
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555432955076, :id "ygDmImJO5a"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432957009, :text "map", :id "0xTffWJlx0"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555432957542, :id "kV4Y90W0a"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432957855, :text "fn", :id "AVz3lLkR6H"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555432958147, :id "Lw6C5otPAZ"
+              :data {
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555432958380, :id "kGR0ue8n8F"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432959557, :text "[]", :id "q0Rv3i2JMc"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432959848, :text "k", :id "naICFp1wWw"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432960432, :text "v", :id "zYABLU_Lnr"}
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555432975350, :id "wHUIkfqWV5"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432976560, :text "[]", :id "wHUIkfqWV5leaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432977243, :text "k", :id "MzMF-AzF23"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555432978264, :id "fTFybRLeJ0"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432978264, :text "read-token", :id "cfjzSjHkGK"}
+                 "f" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432982720, :text "v", :id "IJShTOduqd"}
+                 "p" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432985139, :text "data", :id "fmQvhcHVX"}
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+         "v" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555432963978, :id "XeXCUOLhFk"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432965412, :text "into", :id "XeXCUOLhFkleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555432965773, :id "URgcGLUM5j"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432966114, :text "{}", :id "2KgWnIbGR"}
             }
            }
           }
@@ -25609,10 +25611,23 @@
                     }
                    }
                    "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6CJEF5dEMStH"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555432916899, :id "k1CDaYHolw"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "4ksHe2fZtcmJ"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "se4MzZHHEoxr"}
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432921296, :text "read-styles", :id "gEj3qN3j8L"}
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6CJEF5dEMStH"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "4ksHe2fZtcmJ"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "se4MzZHHEoxr"}
+                      }
+                     }
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555432931208, :id "Sn2F7HlDU"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432931754, :text ":data", :id "y4QIktj1b"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432932914, :text "context", :id "77NFrleynA"}
+                      }
+                     }
                     }
                    }
                   }
@@ -25933,10 +25948,23 @@
                     }
                    }
                    "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nOD2nByBDqqh"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555433129677, :id "7igB-xk9aI"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "qdGXZ01LXOZ_"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "FeTA9dSzxOWJ"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433129677, :text "read-styles", :id "I_5PbLh79t"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433129677, :id "-28DunoOzq"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433129677, :text ":style", :id "LWKnXk1QXP"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433129677, :text "markup", :id "O4FosEg7pR"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433129677, :id "nes27xJwt6"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433129677, :text ":data", :id "I5CRXe74x3"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433129677, :text "context", :id "G8CXFflssx"}
+                      }
+                     }
                     }
                    }
                   }
@@ -26842,10 +26870,23 @@
                     }
                    }
                    "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "5BD_j-quctr8"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555433240638, :id "1YTA7YAxuL"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "8afAIh80iQvc"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "aqciiUHip2_p"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433240638, :text "read-styles", :id "FRzxYQnTdF"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433240638, :id "khn7R0uYwx"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433240638, :text ":style", :id "Ei6qK6JcYz"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433240638, :text "markup", :id "PS8t2Rhf_n"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433240638, :id "4enAVYFe59"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433240638, :text ":data", :id "_pjiWSGxD2"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433240638, :text "context", :id "ZbrjhpWNAI"}
+                      }
+                     }
                     }
                    }
                   }
@@ -27197,14 +27238,14 @@
                      "j" {
                       :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "ic3Dffc5LfCN"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":display", :id "feFx_fdc141l"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433141474, :text "\"display", :id "feFx_fdc141l"}
                        "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":inline-block", :id "Yi-lInZkuoDS"}
                       }
                      }
                      "r" {
                       :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "5tYEZ2Q4FO4D"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":cursor", :id "jhYOGMtVrGKU"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433145588, :text "\"cursor", :id "jhYOGMtVrGKU"}
                        "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":pointer", :id "BKRwqzee3Qxh"}
                       }
                      }
@@ -27590,10 +27631,23 @@
                         }
                        }
                        "v" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1553017133761, :id "lhXWFscJlkp"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433249063, :id "sAvO_bWTC2"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017133761, :text ":style", :id "cMnlRyRsZUZ"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017133761, :text "markup", :id "pWqgEJdp8yd"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433249063, :text "read-styles", :id "YD5lsCZ-0P"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433249063, :id "31yMS16JPh"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433249063, :text ":style", :id "vOd6oEXWQi"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433249063, :text "markup", :id "sAPrjzGOYB"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433249063, :id "upJ7igznZe"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433249063, :text ":data", :id "e_eHtQHnpQ"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433249063, :text "context", :id "xhMUm2HyMi"}
+                          }
+                         }
                         }
                        }
                       }
@@ -27667,55 +27721,61 @@
                       :data {
                        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "merge", :id "qcKeupDOf1h"}
                        "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "ElJiyLcCEso"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433255052, :id "CxuODomB86"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "{}", :id "K3QF5Yv5xfl"}
-                         "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "sjNKNhN9Hs0"
+                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433257673, :text "use-string-keys", :id "S6c8MxB5F"}
+                         "T" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "ElJiyLcCEso"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text ":background-image", :id "ZYvTRSSGcc_"}
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "{}", :id "K3QF5Yv5xfl"}
                            "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "Np6FM2oJIik"
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "sjNKNhN9Hs0"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "<<", :id "M_egpU1gztD"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "\"url(~{src})", :id "5BtqbLkPb5Q"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text ":background-image", :id "ZYvTRSSGcc_"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "Np6FM2oJIik"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "<<", :id "M_egpU1gztD"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "\"url(~{src})", :id "5BtqbLkPb5Q"}
+                              }
+                             }
                             }
                            }
-                          }
-                         }
-                         "r" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "e2QLbkcX7lt"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text ":background-size", :id "NMtGbgnx3qk"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "mode", :id "pmwFZT3E3YD"}
-                          }
-                         }
-                         "v" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1553017812717, :id "tNZaJGJHr"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017813942, :text ":width", :id "tNZaJGJHrleaf"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017815092, :text "width", :id "Et9qHzqmuG"}
-                          }
-                         }
-                         "x" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1553017815943, :id "BDuPvdI6LV"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017817714, :text ":height", :id "BDuPvdI6LVleaf"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017818453, :text "height", :id "lM_JRgQOsG"}
-                          }
-                         }
-                         "y" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1553017838587, :id "wcGJglh0f"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017843821, :text ":background-position", :id "wcGJglh0fleaf"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017846259, :text ":center", :id "mQM66Ukh0y"}
-                          }
-                         }
-                         "yT" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1553017859997, :id "6q-sUyMkFT"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017864559, :text ":background-repeat", :id "6q-sUyMkFTleaf"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017868933, :text ":no-repeat", :id "NPdzL-dmrq"}
+                           "r" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "e2QLbkcX7lt"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text ":background-size", :id "NMtGbgnx3qk"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "mode", :id "pmwFZT3E3YD"}
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553017812717, :id "tNZaJGJHr"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017813942, :text ":width", :id "tNZaJGJHrleaf"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017815092, :text "width", :id "Et9qHzqmuG"}
+                            }
+                           }
+                           "x" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553017815943, :id "BDuPvdI6LV"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017817714, :text ":height", :id "BDuPvdI6LVleaf"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017818453, :text "height", :id "lM_JRgQOsG"}
+                            }
+                           }
+                           "y" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553017838587, :id "wcGJglh0f"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017843821, :text ":background-position", :id "wcGJglh0fleaf"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017846259, :text ":center", :id "mQM66Ukh0y"}
+                            }
+                           }
+                           "yT" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1553017859997, :id "6q-sUyMkFT"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017864559, :text ":background-repeat", :id "6q-sUyMkFTleaf"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017868933, :text ":no-repeat", :id "NPdzL-dmrq"}
+                            }
+                           }
                           }
                          }
                         }
@@ -27747,10 +27807,23 @@
                         }
                        }
                        "x" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1553017547614, :id "mIgmFPIyT6i"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433272015, :id "WPfJFDTkNf"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text ":style", :id "pJLJmu5H0FW"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017547614, :text "markup", :id "gR4kN2bDHkA"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433272015, :text "read-styles", :id "khRIaUmGSM"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433272015, :id "n_sI2MqV60"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433272015, :text ":style", :id "Ags9ViHOx1"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433272015, :text "markup", :id "s50yzMnuoc"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433272015, :id "Qj_9mJF9Nd"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433272015, :text ":data", :id "SiwG092QDm"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433272015, :text "context", :id "C-0xyDiCQ9"}
+                          }
+                         }
                         }
                        }
                       }
@@ -28131,10 +28204,23 @@
                       }
                      }
                      "v" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "GvM503W9I30E"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433197485, :id "TXq9LmCshm"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "_g0zSokat1R-"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "urFo8DajsxIf"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433197485, :text "read-styles", :id "V8KRHnDIBN"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433197485, :id "1M6en3PjR8"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433197485, :text ":style", :id "VPqjC-EgeD"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433197485, :text "markup", :id "55LoufMlm2"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433197485, :id "ZVSnE0XxE-"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433197485, :text ":data", :id "QHDk1DcdPS"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433197485, :text "context", :id "fxYHMpWl0p"}
+                        }
+                       }
                       }
                      }
                     }
@@ -28203,10 +28289,23 @@
                       }
                      }
                      "v" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "gBjCe6HWzGq-"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433198624, :id "OF3djiWz5e"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "YmR_P5eR0kWp"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "K3XQcKz-FTTI"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433198624, :text "read-styles", :id "5lD1HXD-UM"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433198624, :id "e6sGr_GmH8"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433198624, :text ":style", :id "sBUPd-V8NB"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433198624, :text "markup", :id "0m7kD19ogX"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433198624, :id "Ip-Tme_2Ew"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433198624, :text ":data", :id "WQfda4lrOB"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433198624, :text "context", :id "v3JGWlYWVK"}
+                        }
+                       }
                       }
                      }
                     }
@@ -28662,7 +28761,13 @@
                   :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "k0J_69WYnPzV"
                   :data {
                    "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "merge", :id "3q2LSUx2_hQY"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/link", :id "Y6vM3sGkuNtR"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555433170190, :id "_n753eWP4m"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433171025, :text "use-string-keys", :id "de--S01id"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/link", :id "Y6vM3sGkuNtR"}
+                    }
+                   }
                    "n" {
                     :type :expr, :by "B1y7Rc-Zz", :at 1554284966168, :id "TuVg-AjWxp"
                     :data {
@@ -28677,10 +28782,23 @@
                     }
                    }
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Nxz39ajYGQSX"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555433159230, :id "64dLUyyu04"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "gKf4ypmJ0blh"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "4XI0PkZAtByo"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433159230, :text "read-styles", :id "ZbKEHnCRLb"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433159230, :id "UqjgimeOsl"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433159230, :text ":style", :id "i2yHWDEqx_"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433159230, :text "markup", :id "fUQPrAPkxK"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555433159230, :id "1uJTt-HIYy"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433159230, :text ":data", :id "e8arPKectK"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433159230, :text "context", :id "Sh6UqbnA8q"}
+                      }
+                     }
                     }
                    }
                   }
@@ -28985,10 +29103,23 @@
                         }
                        }
                        "v" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "O8XRVPF_C4dr"
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555433207092, :id "P90vgYx9kE"
                         :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "Nlk7aV0ytJkM"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "WU-J__VRl7DA"}
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433207092, :text "read-styles", :id "q251q284Zt"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433207092, :id "XDDFpJK8hq"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433207092, :text ":style", :id "qkrhdBXJfU"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433207092, :text "markup", :id "ZohQV9PXMo"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433207092, :id "7EljpMG05U"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433207092, :text ":data", :id "sRopVJVp0G"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433207092, :text "context", :id "lZ5GTFux1A"}
+                          }
+                         }
                         }
                        }
                       }
@@ -29215,10 +29346,23 @@
                   }
                  }
                  "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "cAEYFDNFmrjV"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555433244302, :id "vz8_EVG3JL"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "nJ6s3xsXjD8g"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "menxqHR50k9k"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433244302, :text "read-styles", :id "QlSKRALGNF"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555433244302, :id "hNYSzO0ink"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433244302, :text ":style", :id "SLwkUEF-2-"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433244302, :text "markup", :id "h2axY4OSH4"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555433244302, :id "KzgmXnZ0jq"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433244302, :text ":data", :id "yyDMcUvFm1"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433244302, :text "context", :id "1tG0UC1ixY"}
+                    }
+                   }
                   }
                  }
                 }
@@ -29876,41 +30020,47 @@
                         :data {
                          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "merge", :id "i0O1AB6EiVMP"}
                          "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "APo0twOy-7OD"
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433226518, :id "2VLpdtsyk"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "NB-l40U-LZLp"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "CbmgobK_N2_2"
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433227398, :text "use-string-keys", :id "2T09lTAXp8"}
+                           "T" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "APo0twOy-7OD"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":margin", :id "_Txcmkxjskkk"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":auto", :id "pJvdSYO5KdoW"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "M3fzLqiqMNsd"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":min-width", :id "KB1FLhlwu073"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "320", :id "sgINHs_ajo4G"}
-                            }
-                           }
-                           "v" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "YAQ1Rlwk3ODf"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":min-height", :id "oRJZLh5PgMyR"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "200", :id "5YppY1dsA-ho"}
-                            }
-                           }
-                           "x" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "n9SyfMLMZVQb"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":background-color", :id "m61CfbcgVT19"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "NB-l40U-LZLp"}
                              "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Qp03gQ0yPOcz"
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "CbmgobK_N2_2"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "hsl", :id "jH7kHYxOtGfA"}
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "0", :id "qe8EdzfsXIgf"}
-                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "0", :id "9m7EJ3r5DOx0"}
-                               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "100", :id "pC_7jC84QqGZ"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":margin", :id "_Txcmkxjskkk"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":auto", :id "pJvdSYO5KdoW"}
+                              }
+                             }
+                             "r" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "M3fzLqiqMNsd"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":min-width", :id "KB1FLhlwu073"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "320", :id "sgINHs_ajo4G"}
+                              }
+                             }
+                             "v" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "YAQ1Rlwk3ODf"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":min-height", :id "oRJZLh5PgMyR"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "200", :id "5YppY1dsA-ho"}
+                              }
+                             }
+                             "x" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "n9SyfMLMZVQb"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":background-color", :id "m61CfbcgVT19"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Qp03gQ0yPOcz"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "hsl", :id "jH7kHYxOtGfA"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "0", :id "qe8EdzfsXIgf"}
+                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "0", :id "9m7EJ3r5DOx0"}
+                                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "100", :id "pC_7jC84QqGZ"}
+                                }
+                               }
                               }
                              }
                             }
@@ -29944,10 +30094,23 @@
                           }
                          }
                          "x" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "pVbU3mw1hzmO"
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555433218436, :id "jwdenLxDeK"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "_OyTJ-hSKb5x"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "q-XutS6mlw18"}
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433218436, :text "read-styles", :id "xSeeZfx4E8"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1555433218436, :id "pWH8OjULOr"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433218436, :text ":style", :id "YVYBEkky2E"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433218436, :text "markup", :id "JuvsHKN-QI"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1555433218436, :id "OKjHachpJC"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433218436, :text ":data", :id "_RbppIZh3B"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433218436, :text "context", :id "aXMVeqkd8B"}
+                            }
+                           }
                           }
                          }
                         }
@@ -30944,10 +31107,23 @@
               }
              }
              "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "S7S88cAeiFhc"
+              :type :expr, :by "B1y7Rc-Zz", :at 1555433185701, :id "HlX1qJ9b8Z"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "-WEGyEP3DtKv"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "fToqz-qRQxZ-"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433185701, :text "read-styles", :id "DMMO9GwN5V"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555433185701, :id "BQckCu_51i"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433185701, :text ":style", :id "zYDnQFuY4G"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433185701, :text "markup", :id "yHbmrqelWR"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555433185701, :id "6h1lWA3gEL"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433185701, :text ":data", :id "SX7LGU6n5E"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555433185701, :text "context", :id "qYF-EHf37s"}
+                }
+               }
               }
              }
             }

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "composer",
-       :version "0.1.6-a1",
+       :version "0.1.6-a2",
        :name "Respo composer renderer library"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/composer/codegen.cljs
+++ b/src/composer/codegen.cljs
@@ -1,4 +1,0 @@
-
-(ns composer.codegen
-  (:require [clojure.string :as string] [favored-edn.core :refer [write-edn]])
-  (:require-macros [clojure.core.strint :refer [<<]]))


### PR DESCRIPTION
Improve expressiveness by allowing expressions in styles. That is used for like setting `background-color` from data.

It will slow down rendering a bit. But for now it's not the focus.
