### PR TITLE
Get a font-family field in editor

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -33193,6 +33193,22 @@
           }
          }
         }
+        "yyy" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555782646505, :id "vW8f4ID_Df"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text "[]", :id "hDiiIlIu-8"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text "composer.util", :id "g3XBjOM-At"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text ":refer", :id "kiA_NOm-T3"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555782646505, :id "Ze1mlee63Y"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text "[]", :id "ngExj4vzdm"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text "pick-port!", :id "GXsk-8uHrh"}
+            "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782962442, :text "specified-port!", :id "0yS4Ucc-tm"}
+           }
+          }
+         }
+        }
        }
       }
       "v" {
@@ -33698,10 +33714,92 @@
          }
         }
        }
-       "v" {
-        :type :expr, :id "HyDtWeIZgCBb", :by nil, :at 1500541255553
+       "vT" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "zGgBORdYnn"
         :data {
-         "T" {:type :leaf, :id "S1_YWgLZlRrb", :text "run-server!", :by "root", :at 1500541255553}
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782674392, :text "pick-port!", :id "sICl-FDwe_"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782913874, :id "WcoM8IyfS"
+          :data {
+           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555783028324, :text "or", :id "snVLe8Uytm"}
+           "L" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782940322, :id "I89qQs_43m"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782948449, :text "specified-port!", :id "716QOfmNRK"}
+            }
+           }
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "HU5jK-oShX"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782674392, :text ":port", :id "M6fFJYLMxg"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782767558, :text "config/site", :id "mIbUks7Qw9"}
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "O3vTrAboQX"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782674392, :text "fn", :id "TNBZmKYJDv"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "NIxs06nxA7"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782678419, :text "port", :id "dBA3jPNkeN"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782689448, :id "w8O-l0JRh6"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782689448, :text "run-server!", :id "7vrlaKMFDE"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782692572, :text "port", :id "QRaHBDIXWF"}
+            }
+           }
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "IdBHwJQONZ"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "let", :id "dy2UMp-w10"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "iqfw6IcC5L"
+              :data {
+               "T" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "ZpO1v_1Fgc"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "link", :id "UU26l1_kR3"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "TiaBvE-JJT"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text ".blue", :id "vcjSheS-nY"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "chalk", :id "SOYyHkaLlD"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "oSGFYDNBAW"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "<<", :id "qrFH2wco6Y"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "\"http://composer.respo-mvc.org?port=~{port}", :id "FGCZF8LMn4"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "FwNxcX-zn-"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "println", :id "y9ko4gUQYL"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "y30OP5MRsY"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "<<", :id "lwJGmhhj1K"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "\"port ~{port} is ok, please edit on ~{link}", :id "8SPKBaQv8gL"}
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
         }
        }
        "w" {
@@ -33729,19 +33827,6 @@
           :data {
            "T" {:type :leaf, :by "root", :at 1524381387239, :text "#()", :id "BJbxCUnYnM"}
            "j" {:type :leaf, :by "root", :at 1524381390653, :text "persist-db!", :id "Hk-QAUhFhM"}
-          }
-         }
-        }
-       }
-       "yT" {
-        :type :expr, :id "rkpyflI-l0B-", :by nil, :at 1500541255553
-        :data {
-         "T" {:type :leaf, :id "SJR1GlLZeCSb", :text "println", :by "root", :at 1500541255553}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551030020579, :id "QCSlTzXee"
-          :data {
-           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551030022069, :text "<<", :id "gq2xPuQfVk"}
-           "T" {:type :leaf, :id "rJ1lMxLWeASZ", :text "\"Server started. Open ~(.blue chalk \"http://composer.respo-mvc.org/\") to edit.", :by "B1y7Rc-Zz", :at 1551030054347}
           }
          }
         }
@@ -33992,19 +34077,15 @@
        "j" {:type :leaf, :id "Hk9_GeUbe0r-", :text "run-server!", :by "root", :at 1500541255553}
        "r" {
         :type :expr, :id "rJj_GeI-lASZ", :by nil, :at 1500541255553
-        :data {}
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782355160, :text "port", :id "Cz8Flds_d"}
+        }
        }
        "x" {
         :type :expr, :by "B1y7Rc-Zz", :at 1544639479135, :id "SD-XH5r7a"
         :data {
          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1544639502455, :text "wss-serve!", :id "SD-XH5r7aleaf"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1544808726190, :id "glaDsXMV3J"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1544808726190, :text ":port", :id "oyCLA596rm"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1544808726190, :text "config/site", :id "k8fp6LfB_8"}
-          }
-         }
+         "f" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782353528, :text "port", :id "SJIHLX8hT1"}
          "r" {
           :type :expr, :by "B1y7Rc-Zz", :at 1544639507467, :id "Ds61YycnTT"
           :data {
@@ -34130,7 +34211,7 @@
                 :type :expr, :by "B1y7Rc-Zz", :at 1544639607005, :id "Xsvj0hSsFk"
                 :data {
                  "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1544809315231, :text "js/console.warn", :id "ifES84g923"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1544639607005, :text "|Client closed!", :id "TmU5V9iQec"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782708516, :text "\"Client closed!", :id "TmU5V9iQec"}
                 }
                }
                "x" {
@@ -42196,6 +42277,42 @@
      :data {
       "T" {:type :leaf, :by "root", :at 1548675189918, :text "ns", :id "nXJtQEuLEW"}
       "j" {:type :leaf, :by "root", :at 1548675189918, :text "composer.util", :id "qsA7JO-NOJ"}
+      "r" {
+       :type :expr, :by "B1y7Rc-Zz", :at 1555782539455, :id "jkYia3D346"
+       :data {
+        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782540255, :text ":require", :id "PArLR8kk0r"}
+        "j" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555782541105, :id "e_7R3KCJdE"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782541356, :text "[]", :id "cl-44cDf37"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782542500, :text "\"net", :id "QntnHHrDT2"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782542936, :text ":as", :id "IgoGhgW9h"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782543516, :text "net", :id "k5FpzWNUWj"}
+         }
+        }
+       }
+      }
+      "v" {
+       :type :expr, :by "B1y7Rc-Zz", :at 1555782803021, :id "mLMORtgRs3"
+       :data {
+        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782803021, :text ":require-macros", :id "8m1V4JzkPE"}
+        "j" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555782803021, :id "zKgyk8L0U-"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782803021, :text "[]", :id "MThesBdutG"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782803021, :text "clojure.core.strint", :id "jtXWIvq6IA"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782803021, :text ":refer", :id "akZ8i9LXFU"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555782803021, :id "UR-YSMlqsx"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782803021, :text "[]", :id "qlbCEzxiZ9"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782803021, :text "<<", :id "enH9nEgs13"}
+           }
+          }
+         }
+        }
+       }
+      }
      }
     }
     :defs {
@@ -42553,6 +42670,334 @@
              "j" {:type :leaf, :by "root", :at 1548675228907, :text ":children", :id "FHXDGtHXC9"}
             }
            }
+          }
+         }
+        }
+       }
+      }
+     }
+     "pick-port!" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "j-kh6MUXVS"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "defn", :id "z-eisAjxE6"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "pick-port!", :id "Nf7S0Bf5pd"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "7XmycJaYt-"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "8luc3g-OnZ"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "next-fn", :id "yfcDTeeb9g"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "d7YXfEEHk-"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port-taken?", :id "9XiFaRctTE"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "uKCL33KBt6"}
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "1d-hAQLkRU"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "fn", :id "iIHnj8YM9N"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "sMDFdVnwdp"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "err", :id "6z2AXvCTrM"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "taken?", :id "oY-KJ4oK_I"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "fhfDjFD2NM"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "if", :id "0dSiascQPFR"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "558MYSLus2F"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "some?", :id "41Y7inP3cQM"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "err", :id "jPTLSajKXdI"}
+              }
+             }
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "bNkW7TNSO9R"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "do", :id "zgQ2srI0hKS"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "PcWNx7WTKIf"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text ".error", :id "QSPrfEqBrZZ"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "js/console", :id "yp5E_wcaKtZ"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "err", :id "-ImYeUTHfQY"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "QYkVZaiqi4D"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text ".exit", :id "xncdLyVZ8jG"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "js/process", :id "kOAepJQQUZt"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "1", :id "krmrHLodFX5"}
+                }
+               }
+              }
+             }
+             "v" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "V-aZ7hW2wtK"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "if", :id "YmpFxIvCZB3"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "taken?", :id "HduHjyyGYY3"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "4UnF6KyjD1_"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "do", :id "MZeuNzsnmF1"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782610749, :id "k8ENH3FeeV"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782613320, :text "println", :id "cvYHW6zJB9"}
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "gAyg_e1L7op"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782616097, :text "<<", :id "Ii0mPECX-Go"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782626788, :text "\"port ~{port} is in use.", :id "vruRA0-cSoO"}
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "YwQLsl5fti6"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "pick-port!", :id "frsIs7LkYhs"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "ltyTqcoWUye"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "inc", :id "3P5DABmHZFv"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "Ku4JBru3_E4"}
+                    }
+                   }
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "next-fn", :id "d4PVCJZmqGt"}
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "FVBpEoZuAcM"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "next-fn", :id "BXAbY3v6TWH"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "o-OTsA64GrP"}
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "port-taken?" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "vzSywzFVL-"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "defn", :id "dIHF4GG4ar"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "port-taken?", :id "UNi8Rj7jjN"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "3-cDOnOuzk"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "port", :id "Pcyq_4zvzu"}
+         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "nOVI20WDYq"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "MQhDJmS_0Z"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "let", :id "JxmZxBP9QH"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "Mbj5QHfvDA"
+          :data {
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "M_HIzC7g0D"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "tester", :id "HjXTWepU2o4"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "BWi1IF_VE18"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text ".createServer", :id "JdaCx-OqlRu"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "net", :id "ZkF2sSl9UKy"}
+              }
+             }
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "yblZcD7vnZP"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "..", :id "AvCyISzWNzI"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "tester", :id "rItuldcCgNS"}
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "Kbs-YMg9_Eq"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "once", :id "8sOnJ-sNzSn"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782548099, :text "\"error", :id "Vw8LGa1jPOh"}
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "v6CnA9sYGUU"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "fn", :id "MwzF2LfwMjq"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "w6OFPkXF0E8"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "err", :id "5z08VyKXNSF"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "ClCr1H7MwT8"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "if", :id "6JO4NTzkMbE"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "sDITcDL2eGP"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "not=", :id "cWtyuAMbFgE"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "d6oaR_K1763"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text ".-code", :id "AVlsWT2N7Oa"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "err", :id "jspD27_i24-"}
+                    }
+                   }
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782553063, :text "\"EADDRINUSE", :id "TC3k8Ip5zKZ"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "NlL50oLSYdg"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "FgCXmz6xHKj"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "err", :id "_wfWgSrT65E"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "false", :id "uueBrC0Q7y3"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "4AD4cObn11Y"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "3nvA6TT7vAH"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "nil", :id "F7yF09SPZxT"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "true", :id "janFakfGRRV"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "3XbqcUlrLML"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "once", :id "i3JCZFL4SN9"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782550920, :text "\"listening", :id "738DcMziOJi"}
+             "r" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "wH5l93Y0blk"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "fn", :id "xmn_Onmx268"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "PNGgbwvrymS"
+                :data {}
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "wCxeZMt-nB4"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "..", :id "qPH5KzOUc9b"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "tester", :id "eyyriwwaKe1"}
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "9Lt2zSEllXQ"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "once", :id "DF0wcGoCBrG"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782557652, :text "\"close", :id "z06kEkuvn50"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "Y_psUfKruDS"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "fn", :id "cbVLd_0Eq1r"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "QKsCsNnlzuD"
+                      :data {}
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "gks1W3fLKU2"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "2zp_sYgH4EK"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "nil", :id "i9tqCsQF5aG"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "false", :id "IK19bntnMFu"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "IuXu0Cs_JxT"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "close", :id "qpjSCT47Yhs"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "_YmDQQvjps9"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "listen", :id "t2W2uSPErn_"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "port", :id "UIgtNIGgPj_"}
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "specified-port!" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1555782967141, :id "UIicyJkx9k"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782967141, :text "defn", :id "rj5cripnTa"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782967141, :text "specified-port!", :id "V59uC3guBu"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782967141, :id "c4Z_vQ3-P2"
+        :data {}
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555782972197, :id "gjf_syax5n"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782972710, :text "let", :id "gjf_syax5nleaf"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782972936, :id "pn97x544kz"
+          :data {
+           "T" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782973068, :id "0Q41G7ZvLC"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782974514, :text "raw", :id "LNf1QPloE-"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782984163, :text "js/process.env.port", :id "S4igbLJDQ"}
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555782985490, :id "GkLxWSkmV-"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782985837, :text "if", :id "GkLxWSkmV-leaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555782987018, :id "5YNLuq9NW"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782987952, :text "some?", :id "fGdl-gwrXA"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782990377, :text "raw", :id "L9_oSuZK6c"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555783002318, :id "ftRAdvYlEP"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555783005387, :text "js/parseInt", :id "ftRAdvYlEPleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555783006423, :text "raw", :id "KFsnlCmSv"}
+            }
+           }
+           "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555783008839, :text "nil", :id "MFLcOtw8nH"}
           }
          }
         }

--- a/calcit.edn
+++ b/calcit.edn
@@ -33203,8 +33203,38 @@
            :type :expr, :by "B1y7Rc-Zz", :at 1555782646505, :id "Ze1mlee63Y"
            :data {
             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text "[]", :id "ngExj4vzdm"}
-            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782646505, :text "pick-port!", :id "GXsk-8uHrh"}
             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782962442, :text "specified-port!", :id "0yS4Ucc-tm"}
+           }
+          }
+         }
+        }
+        "yyyT" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555828766393, :id "yxAdWSWTjy"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828766694, :text "[]", :id "yxAdWSWTjyleaf"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828772265, :text "clojure.core.async", :id "p2A0LB9_E6"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828773713, :text ":refer", :id "G1GI0c1Z9l"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555828773920, :id "sGKgvGScv6"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828774179, :text "[]", :id "waAKJyNGyh"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828776265, :text "go", :id "CJpkeQt6F4"}
+            "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828780667, :text "<!", :id "eqNRvhNm-"}
+           }
+          }
+         }
+        }
+        "yyyj" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555828828424, :id "9Dj3zxupIP"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828829066, :text "[]", :id "9Dj3zxupIPleaf"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828834748, :text "cumulo-util.file", :id "Z7gkWZCFrz"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828835455, :text ":refer", :id "S8LNeNthEQ"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555828835720, :id "a862yX92xB"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828836120, :text "[]", :id "SI4m2Mq3O"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828836938, :text "chan-pick-port", :id "sVlGtIuov"}
            }
           }
          }
@@ -33714,67 +33744,84 @@
          }
         }
        }
-       "vT" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "zGgBORdYnn"
+       "vj" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555828783625, :id "M9MXqwdB2"
         :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782674392, :text "pick-port!", :id "sICl-FDwe_"}
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828783973, :text "go", :id "M9MXqwdB2leaf"}
          "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1555782913874, :id "WcoM8IyfS"
+          :type :expr, :by "B1y7Rc-Zz", :at 1555828784581, :id "JlBufH6Oi"
           :data {
-           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555783028324, :text "or", :id "snVLe8Uytm"}
-           "L" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782940322, :id "I89qQs_43m"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782948449, :text "specified-port!", :id "716QOfmNRK"}
-            }
-           }
-           "T" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "HU5jK-oShX"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782674392, :text ":port", :id "M6fFJYLMxg"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782767558, :text "config/site", :id "mIbUks7Qw9"}
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "O3vTrAboQX"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782674392, :text "fn", :id "TNBZmKYJDv"}
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828785410, :text "let", :id "tZo89I3c4E"}
            "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782674392, :id "NIxs06nxA7"
+            :type :expr, :by "B1y7Rc-Zz", :at 1555828785701, :id "v-g6_D_Rs"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782678419, :text "port", :id "dBA3jPNkeN"}
+             "T" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555828785842, :id "eagtoaF4vL"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828946780, :text "port", :id "fkXqvr0Ozz"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555828966191, :id "EyJYKRejGv"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828967270, :text "<!", :id "gzYMcDMjtM"}
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555828789846, :id "DDQXqRE4_"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828797036, :text "chan-pick-port", :id "tKv1q6POk"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555828804606, :id "kbb5CHraUF"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828804606, :text "or", :id "BQ9s005hju"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555828804606, :id "ohQD98Fnnr"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828804606, :text "specified-port!", :id "dPwxMcM8mF"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555828804606, :id "DejRq2ApcC"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828804606, :text ":port", :id "WdEMOxBH1M"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828804606, :text "config/site", :id "plRhI-IakP"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "0NhNd9cmZg"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "run-server!", :id "fW7mLN2pgH"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "port", :id "aZUsvFtRJ_"}
             }
            }
            "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782689448, :id "w8O-l0JRh6"
+            :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "d2wCe_BBQM"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782689448, :text "run-server!", :id "7vrlaKMFDE"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782692572, :text "port", :id "QRaHBDIXWF"}
-            }
-           }
-           "x" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "IdBHwJQONZ"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "let", :id "dy2UMp-w10"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "let", :id "V0QDDT8k8_"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "iqfw6IcC5L"
+              :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "q_ba9AGJbQ"
               :data {
                "T" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "ZpO1v_1Fgc"
+                :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "O1rEREGn0-"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "link", :id "UU26l1_kR3"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "link", :id "03pQZxKLf_"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "TiaBvE-JJT"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "_CBsymv5NnJ"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text ".blue", :id "vcjSheS-nY"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "chalk", :id "SOYyHkaLlD"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text ".blue", :id "NReVlAae1oh"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "chalk", :id "KpGDB2Ex1k8"}
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "oSGFYDNBAW"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "3gRuLhbpHut"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "<<", :id "qrFH2wco6Y"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "\"http://composer.respo-mvc.org?port=~{port}", :id "FGCZF8LMn4"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "<<", :id "8bBK4p1preM"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "\"http://composer.respo-mvc.org?port=~{port}", :id "14nDxaJ_B0a"}
                     }
                    }
                   }
@@ -33784,14 +33831,14 @@
               }
              }
              "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "FwNxcX-zn-"
+              :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "OKasZDSjBEp"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "println", :id "y9ko4gUQYL"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "println", :id "ByALYU86l7K"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782731771, :id "y30OP5MRsY"
+                :type :expr, :by "B1y7Rc-Zz", :at 1555828811484, :id "fiE-DApfIc2"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "<<", :id "lwJGmhhj1K"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782731771, :text "\"port ~{port} is ok, please edit on ~{link}", :id "8SPKBaQv8gL"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "<<", :id "3QAEFAq7Df2"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555828811484, :text "\"port ~{port} is ok, please edit on ~{link}", :id "-c7b41WCMj5"}
                 }
                }
               }
@@ -42277,21 +42324,6 @@
      :data {
       "T" {:type :leaf, :by "root", :at 1548675189918, :text "ns", :id "nXJtQEuLEW"}
       "j" {:type :leaf, :by "root", :at 1548675189918, :text "composer.util", :id "qsA7JO-NOJ"}
-      "r" {
-       :type :expr, :by "B1y7Rc-Zz", :at 1555782539455, :id "jkYia3D346"
-       :data {
-        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782540255, :text ":require", :id "PArLR8kk0r"}
-        "j" {
-         :type :expr, :by "B1y7Rc-Zz", :at 1555782541105, :id "e_7R3KCJdE"
-         :data {
-          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782541356, :text "[]", :id "cl-44cDf37"}
-          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782542500, :text "\"net", :id "QntnHHrDT2"}
-          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782542936, :text ":as", :id "IgoGhgW9h"}
-          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782543516, :text "net", :id "k5FpzWNUWj"}
-         }
-        }
-       }
-      }
       "v" {
        :type :expr, :by "B1y7Rc-Zz", :at 1555782803021, :id "mLMORtgRs3"
        :data {
@@ -42668,284 +42700,6 @@
             :data {
              "T" {:type :leaf, :by "root", :at 1548675227159, :text "repeat", :id "UAJKm4MfX"}
              "j" {:type :leaf, :by "root", :at 1548675228907, :text ":children", :id "FHXDGtHXC9"}
-            }
-           }
-          }
-         }
-        }
-       }
-      }
-     }
-     "pick-port!" {
-      :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "j-kh6MUXVS"
-      :data {
-       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "defn", :id "z-eisAjxE6"}
-       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "pick-port!", :id "Nf7S0Bf5pd"}
-       "r" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "7XmycJaYt-"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "8luc3g-OnZ"}
-         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "next-fn", :id "yfcDTeeb9g"}
-        }
-       }
-       "v" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "d7YXfEEHk-"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port-taken?", :id "9XiFaRctTE"}
-         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "uKCL33KBt6"}
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "1d-hAQLkRU"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "fn", :id "iIHnj8YM9N"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "sMDFdVnwdp"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "err", :id "6z2AXvCTrM"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "taken?", :id "oY-KJ4oK_I"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "fhfDjFD2NM"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "if", :id "0dSiascQPFR"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "558MYSLus2F"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "some?", :id "41Y7inP3cQM"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "err", :id "jPTLSajKXdI"}
-              }
-             }
-             "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "bNkW7TNSO9R"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "do", :id "zgQ2srI0hKS"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "PcWNx7WTKIf"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text ".error", :id "QSPrfEqBrZZ"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "js/console", :id "yp5E_wcaKtZ"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "err", :id "-ImYeUTHfQY"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "QYkVZaiqi4D"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text ".exit", :id "xncdLyVZ8jG"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "js/process", :id "kOAepJQQUZt"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "1", :id "krmrHLodFX5"}
-                }
-               }
-              }
-             }
-             "v" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "V-aZ7hW2wtK"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "if", :id "YmpFxIvCZB3"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "taken?", :id "HduHjyyGYY3"}
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "4UnF6KyjD1_"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "do", :id "MZeuNzsnmF1"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782610749, :id "k8ENH3FeeV"
-                  :data {
-                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782613320, :text "println", :id "cvYHW6zJB9"}
-                   "T" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "gAyg_e1L7op"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782616097, :text "<<", :id "Ii0mPECX-Go"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782626788, :text "\"port ~{port} is in use.", :id "vruRA0-cSoO"}
-                    }
-                   }
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "YwQLsl5fti6"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "pick-port!", :id "frsIs7LkYhs"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "ltyTqcoWUye"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "inc", :id "3P5DABmHZFv"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "Ku4JBru3_E4"}
-                    }
-                   }
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "next-fn", :id "d4PVCJZmqGt"}
-                  }
-                 }
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782486736, :id "FVBpEoZuAcM"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "next-fn", :id "BXAbY3v6TWH"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782486736, :text "port", :id "o-OTsA64GrP"}
-                }
-               }
-              }
-             }
-            }
-           }
-          }
-         }
-        }
-       }
-      }
-     }
-     "port-taken?" {
-      :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "vzSywzFVL-"
-      :data {
-       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "defn", :id "dIHF4GG4ar"}
-       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "port-taken?", :id "UNi8Rj7jjN"}
-       "r" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "3-cDOnOuzk"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "port", :id "Pcyq_4zvzu"}
-         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "nOVI20WDYq"}
-        }
-       }
-       "v" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "MQhDJmS_0Z"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "let", :id "JxmZxBP9QH"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "Mbj5QHfvDA"
-          :data {
-           "T" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "M_HIzC7g0D"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "tester", :id "HjXTWepU2o4"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "BWi1IF_VE18"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text ".createServer", :id "JdaCx-OqlRu"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "net", :id "ZkF2sSl9UKy"}
-              }
-             }
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "yblZcD7vnZP"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "..", :id "AvCyISzWNzI"}
-           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "tester", :id "rItuldcCgNS"}
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "Kbs-YMg9_Eq"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "once", :id "8sOnJ-sNzSn"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782548099, :text "\"error", :id "Vw8LGa1jPOh"}
-             "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "v6CnA9sYGUU"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "fn", :id "MwzF2LfwMjq"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "w6OFPkXF0E8"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "err", :id "5z08VyKXNSF"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "ClCr1H7MwT8"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "if", :id "6JO4NTzkMbE"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "sDITcDL2eGP"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "not=", :id "cWtyuAMbFgE"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "d6oaR_K1763"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text ".-code", :id "AVlsWT2N7Oa"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "err", :id "jspD27_i24-"}
-                    }
-                   }
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782553063, :text "\"EADDRINUSE", :id "TC3k8Ip5zKZ"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "NlL50oLSYdg"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "FgCXmz6xHKj"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "err", :id "_wfWgSrT65E"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "false", :id "uueBrC0Q7y3"}
-                  }
-                 }
-                 "v" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "4AD4cObn11Y"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "3nvA6TT7vAH"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "nil", :id "F7yF09SPZxT"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "true", :id "janFakfGRRV"}
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "3XbqcUlrLML"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "once", :id "i3JCZFL4SN9"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782550920, :text "\"listening", :id "738DcMziOJi"}
-             "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "wH5l93Y0blk"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "fn", :id "xmn_Onmx268"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "PNGgbwvrymS"
-                :data {}
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "wCxeZMt-nB4"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "..", :id "qPH5KzOUc9b"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "tester", :id "eyyriwwaKe1"}
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "9Lt2zSEllXQ"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "once", :id "DF0wcGoCBrG"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782557652, :text "\"close", :id "z06kEkuvn50"}
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "Y_psUfKruDS"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "fn", :id "cbVLd_0Eq1r"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "QKsCsNnlzuD"
-                      :data {}
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "gks1W3fLKU2"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "next-fn", :id "2zp_sYgH4EK"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "nil", :id "i9tqCsQF5aG"}
-                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "false", :id "IK19bntnMFu"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                 "v" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "IuXu0Cs_JxT"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "close", :id "qpjSCT47Yhs"}
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "x" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1555782536326, :id "_YmDQQvjps9"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "listen", :id "t2W2uSPErn_"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555782536326, :text "port", :id "UIgtNIGgPj_"}
             }
            }
           }

--- a/calcit.edn
+++ b/calcit.edn
@@ -1910,11 +1910,11 @@
        }
       }
      }
-     "comp-font-picker" {
+     "comp-font-color-picker" {
       :type :expr, :by "B1y7Rc-Zz", :at 1553016322046, :id "1aLyHdKmOj"
       :data {
        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016322046, :text "defcomp", :id "kQ4Iti3HuQ"}
-       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016323606, :text "comp-font-picker", :id "DgM5doh5gJ"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016323606, :text "comp-font-color-picker", :id "DgM5doh5gJ"}
        "r" {
         :type :expr, :by "B1y7Rc-Zz", :at 1553016322046, :id "9N0kLYomXf"
         :data {
@@ -4914,7 +4914,7 @@
            :data {
             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549209493194, :text "[]", :id "miF2yfl7nm"}
             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549209493194, :text "comp-bg-picker", :id "xrxYNyV9t8"}
-            "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016357291, :text "comp-font-picker", :id "5HFbs5qX-t"}
+            "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693303839, :text "comp-font-color-picker", :id "5HFbs5qX-t"}
            }
           }
          }
@@ -5422,13 +5422,6 @@
                        "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text ":auto", :id "6IIsMrj4YE"}
                       }
                      }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1555692417430, :id "dR4YIsfo9y"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text ":padding", :id "MDuAvKvdUs"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text "8", :id "L7mdMpn6a9"}
-                      }
-                     }
                     }
                    }
                   }
@@ -5449,7 +5442,26 @@
                   :type :expr, :by "B1y7Rc-Zz", :at 1555692442148, :id "Df4CzmBuay"
                   :data {
                    "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692443369, :text ":style", :id "HSuqSEBkWJ"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692445651, :text "ui/expand", :id "OCgaqH0j07"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555693869852, :id "_JJS9-4gux"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693873029, :text "merge", :id "ZFFxsorpeO"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692445651, :text "ui/expand", :id "OCgaqH0j07"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555693875294, :id "Y8uivNwz0"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693875809, :text "{}", :id "nsaKulWua"}
+                       "T" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555693873661, :id "UYBvod3j5_"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693873661, :text ":padding", :id "jD2uvB_mEo"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693873661, :text "8", :id "tN8gydMgDA"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
                   }
                  }
                 }
@@ -5815,7 +5827,33 @@
                   :type :expr, :by "B1y7Rc-Zz", :at 1555692432722, :id "85FiB4Zx2W"
                   :data {
                    "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692435772, :text ":style", :id "AGrF09HmL"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692438791, :text "ui/expand", :id "IUj8WmGLqE"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555693836567, :id "Zk8UaVwPs"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693837775, :text "merge", :id "nSKNNgpLnH"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692438791, :text "ui/expand", :id "IUj8WmGLqE"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555693838368, :id "ptW9hDRXYc"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693838702, :text "{}", :id "F50W2urfXt"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555693838994, :id "kHVmlHc3qR"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693844081, :text ":border-left", :id "y5175rD-9P"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693906211, :text "\"1px solid #f4f4f4", :id "YkkXskhF-p"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555693879618, :id "wEu8j2F9Ib"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693879618, :text ":padding", :id "6Chlgoptv3"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693879618, :text "8", :id "FU72c_Jwr4"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
                   }
                  }
                 }
@@ -5888,7 +5926,7 @@
                 :data {
                  "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "cursor->", :id "0jN4OxxYpI"}
                  "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text ":font-color", :id "eOlBK8CVuL"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "comp-font-picker", :id "V0euyW9J0L"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693307141, :text "comp-font-color-picker", :id "V0euyW9J0L"}
                  "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "states", :id "MEgT-gmWBU"}
                  "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "template-id", :id "l1a06gnU7-"}
                  "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "focused-path", :id "mw6qqGZHvh"}
@@ -5898,6 +5936,104 @@
                   :data {
                    "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text ":colors", :id "huOBp8A7mr"}
                    "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "settings", :id "UKHPEdlKeD"}
+                  }
+                 }
+                }
+               }
+               "t" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692490310, :id "Uuw2WorqF"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "cursor->", :id "0jN4OxxYpI"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693158956, :text ":fontface", :id "eOlBK8CVuL"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693153996, :text "comp-fontface-picker", :id "V0euyW9J0L"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "states", :id "MEgT-gmWBU"}
+                 "yT" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555693204600, :id "vzLxVjU63n"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693204600, :text "get-in", :id "SYbt36pdX7"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693488221, :text "child", :id "ZxGRyjD77x"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555693204600, :id "CiWNRFlNgI"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693204600, :text "[]", :id "nV_eFm9ttc"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693204600, :text ":style", :id "Xi7_mmNrTe"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693211776, :text "\"font-family", :id "JCIX8nHJsu"}
+                    }
+                   }
+                  }
+                 }
+                 "yj" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555693582973, :id "2B3bj2LyY"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693584330, :text "fn", :id "2B3bj2LyYleaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555693584602, :id "1Y4xheo4a"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693587816, :text "result", :id "67bxeaS1AR"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693667287, :text "d!", :id "oZSHoIH9UK"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693668092, :text "m!", :id "XRfKdGTxs"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555693591388, :id "C-iHrsYG5r"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text "d!", :id "nvbctPWrfL"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text ":template/node-style", :id "mHyBzA3ObL"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555693591388, :id "yDhZ0INx2B"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text "merge", :id "itv2Bc-q75"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555693591388, :id "fVUBcXNJLA"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text "{}", :id "WAcqWccidN"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555693591388, :id "bD0erBHKFq"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text ":template-id", :id "1pfX4rSlR2"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text "template-id", :id "XZMvlDZKq1"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555693591388, :id "l2oQIcKGpt"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text ":path", :id "kZA55BrP1e"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693591388, :text "focused-path", :id "f1PFKHC-uu"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1555693640208, :id "8LR9NJcz5O"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693640208, :text "{}", :id "Kpo7WsiP0a"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555693640208, :id "I0J9wLNEE5"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693640208, :text ":type", :id "BeoFaIFwY-"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693640208, :text ":set", :id "z08iG-tsFy"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555693640208, :id "3CtWW_697A"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693640208, :text ":key", :id "e3YPG-Lw1k"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693646778, :text "\"font-family", :id "xz_cHdYN2n"}
+                          }
+                         }
+                         "v" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555693640208, :id "TI3k7Crlhf"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693640208, :text ":value", :id "_xT0gKblS-"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693640208, :text "result", :id "yQtm09-R7K"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
                   }
                  }
                 }
@@ -5921,6 +6057,103 @@
                  }
                 }
                }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "comp-fontface-picker" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1555693216492, :id "gvKG5HKxmn"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693475800, :text "defcomp", :id "dVfZh9gpWn"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693216492, :text "comp-fontface-picker", :id "JN1D7LBerC"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555693277831, :id "BWewePtVs-"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693277831, :text "states", :id "ZGj-Jsv6MU"}
+         "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693322817, :text "fontface", :id "wPFGIt2Twl"}
+         "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693570488, :text "on-select", :id "GikzIrc2C"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "WGCwA4Sqtb"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "div", :id "-y7YNlkxgh"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "eiHjmb-5_4"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "{}", :id "IbgmaMvFZM"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "Zuxp7I6SJU"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text ":style", :id "u_wbmHNKfJ"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "ui/row-middle", :id "Zx5EcUhJor"}
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "1N3fXjlf_i"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "<>", :id "Q99rVOwY34"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693530988, :text "\"Font family:", :id "f_PnjVwPin"}
+           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "style/field-label", :id "5dFdFVELpg"}
+          }
+         }
+         "v" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "IARedyY1XX"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "=<", :id "pjV4vhoyJ3"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "8", :id "w1GNk9olhIR"}
+           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "nil", :id "n0ZojuJMzas"}
+          }
+         }
+         "x" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "LYPVl57bN9S"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "cursor->", :id "jXYELaifG3_"}
+           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text ":font-color", :id "vXGTDqBil8o"}
+           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693352874, :text "comp-select", :id "23ipWYeZoSO"}
+           "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "states", :id "51qGWfGTO-N"}
+           "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693367074, :text "fontface", :id "gH5Bvc7fX"}
+           "wT" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693380023, :text "fontface-choices", :id "gurEWvlEA"}
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "e1YzGJV62Q1"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "{}", :id "bYWxgk2dU6O"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "Zh-AzD9OirU"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693439219, :text ":text", :id "waT0n2owzs1"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693443528, :text "\"Select fontface", :id "CWOizirIp"}
+              }
+             }
+            }
+           }
+           "y" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "KD89UD_osXs"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693228347, :text "fn", :id "oOFQu1LHTHD"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555693228347, :id "SQ2DlojdYp2"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693448153, :text "result", :id "oi1AvR6KHDP"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693449131, :text "d!", :id "fBpa1GiB1"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693449923, :text "m!", :id "spPORPSGhl"}
+              }
+             }
+             "v" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1555693572178, :id "T9qlWHLfCQ"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693576724, :text "on-select", :id "T9qlWHLfCQleaf"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693577631, :text "result", :id "519AJdCH0w"}
+               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693662280, :text "d!", :id "fd8wVzgt6v"}
+               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693663233, :text "m!", :id "fI_NPhHEo"}
               }
              }
             }
@@ -7512,6 +7745,79 @@
                }
               }
              }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "fontface-choices" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1555693380887, :id "t1KuqJDv73"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693381783, :text "def", :id "qrliW2FmON"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693380887, :text "fontface-choices", :id "mvitdY5ewK"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1555693380887, :id "8qK-ABi-vo"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693383425, :text "[]", :id "bKW33hZLf"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693383916, :id "yB0TSb71GQ"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693384972, :text "{}", :id "WL5RDBfQe"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693385270, :id "bT3oMB3eez"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693385930, :text ":value", :id "Tp2B3yk_rN"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693393771, :text "ui/font-fancy", :id "77cZ1Gq5Xk"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693397631, :id "1nsg4OI65"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693400648, :text ":display", :id "1nsg4OI65leaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693402890, :text "\"Fancy", :id "uBMcRUrTZa"}
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693383916, :id "2B9K4Vr9a"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693384972, :text "{}", :id "WL5RDBfQe"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693385270, :id "bT3oMB3eez"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693385930, :text ":value", :id "Tp2B3yk_rN"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693412891, :text "ui/font-code", :id "77cZ1Gq5Xk"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693397631, :id "1nsg4OI65"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693400648, :text ":display", :id "1nsg4OI65leaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693414530, :text "\"Code", :id "uBMcRUrTZa"}
+            }
+           }
+          }
+         }
+         "v" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1555693383916, :id "crZH3NTPg6"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693384972, :text "{}", :id "WL5RDBfQe"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693385270, :id "bT3oMB3eez"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693385930, :text ":value", :id "Tp2B3yk_rN"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693419807, :text "ui/font-normal", :id "77cZ1Gq5Xk"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1555693397631, :id "1nsg4OI65"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693400648, :text ":display", :id "1nsg4OI65leaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555693423304, :text "\"Normal", :id "uBMcRUrTZa"}
             }
            }
           }
@@ -14275,21 +14581,6 @@
         :type :expr, :by "B1y7Rc-Zz", :at 1554632494882, :id "1RFLjrAQKj"
         :data {
          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554632495562, :text "{}", :id "zR3sxlSfG"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1554632496809, :id "_ZGw-CiUNp"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554633111887, :text "\"Fonts", :id "RfBz2uyel"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1554632745419, :id "2piZEBSFCV"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554632765439, :text "[]", :id "kOIRa2vhmr"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554632768497, :text ":font-code", :id "OGAyJ7DsC"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1554632770835, :text ":font-fancy", :id "_k3eK1vsp"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1554632774614, :text ":font-normal", :id "c1FpZLyps8"}
-            }
-           }
-          }
-         }
          "r" {
           :type :expr, :by "B1y7Rc-Zz", :at 1554632776430, :id "vhAN55ahV"
           :data {
@@ -24566,63 +24857,6 @@
                    "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226458144, :text ":auto", :id "tdr_wwl_a"}
                   }
                  }
-                }
-               }
-              }
-             }
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "gqBhW6xmDk5Z"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884540209, :text ":font-code", :id "DM7DkzCzki3x"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "MN9JMw229MhU"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "9Kvwd1IAgNTs"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "nI1K-kBF7jn4"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884547110, :text "\"font-family", :id "ekrI7F9SzZwE"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-code", :id "N84KYhxPKNeE"}
-                }
-               }
-              }
-             }
-            }
-           }
-           "x" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Xp5IPp31wXrF"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":font-fancy", :id "SH-ou6H6ajr1"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "jtU8UGL3xxaN"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "n4K487R4PZQH"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "9nWn_dcaDJm4"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884548849, :text "\"font-family", :id "_55sXn_l-TXW"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-fancy", :id "brUiVKUGOOUa"}
-                }
-               }
-              }
-             }
-            }
-           }
-           "y" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6MAyAbJ9hfgK"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":font-normal", :id "MpvVQWfS1k4M"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "Y6gdrvbMi0eX"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "{}", :id "GLwOOVw4mmaz"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "lFmSQkSVjJFS"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554884550874, :text "\"font-family", :id "pua3jdVE0L8F"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "ui/font-normal", :id "n3aIn9Wf6X9r"}
                 }
                }
               }

--- a/calcit.edn
+++ b/calcit.edn
@@ -13593,76 +13593,83 @@
                           :data {
                            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671837038, :text "style-container", :id "JVL9MEm3DW"}
                            "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "lL50Aio7JU"
+                            :type :expr, :by "B1y7Rc-Zz", :at 1555865929711, :id "C0dwFACXE"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "{}", :id "LdIqzElfHd"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "XFH3hN3aOt"
+                             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555865931956, :text "merge", :id "GuE5SanS-D"}
+                             "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1555865933494, :text "ui/column", :id "vFmB2lQbT-"}
+                             "T" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "lL50Aio7JU"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":background-color", :id "QryK72gsdl"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "{}", :id "LdIqzElfHd"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "NZdeiEI8tu"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "XFH3hN3aOt"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "hsl", :id "n4eDwDHOEA"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "PCL-jWP6Wk"}
-                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "urWeROl4xK"}
-                                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "100", :id "ZpPX3Ag6MS"}
-                                }
-                               }
-                              }
-                             }
-                             "r" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "dkoFSrgZiS"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":border", :id "cYpHc1d8S7"}
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "\"1px solid #ddd", :id "s2pX1IabjJ"}
-                              }
-                             }
-                             "x" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "jgWbg9rbVpA"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671903479, :text ":min-width", :id "To4fds_9gIy"}
-                               "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671932876, :id "N9a0Ziyry"
-                                :data {
-                                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671935197, :text "or", :id "w-pL4kO8Xw"}
-                                 "T" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "2ikB4H4BF2k"
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":background-color", :id "QryK72gsdl"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "NZdeiEI8tu"
                                   :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":width", :id "i1S_nwbSmqn"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "BxnBqnHoSuK"}
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "hsl", :id "n4eDwDHOEA"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "PCL-jWP6Wk"}
+                                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "0", :id "urWeROl4xK"}
+                                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "100", :id "ZpPX3Ag6MS"}
                                   }
                                  }
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671937746, :text "240", :id "bMkvreDze"}
                                 }
                                }
-                              }
-                             }
-                             "y" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "sZvPiyvtP04"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671905455, :text ":min-height", :id "6EkiYviXbHO"}
-                               "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1552671939151, :id "WcpTGos80j"
+                               "r" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "dkoFSrgZiS"
                                 :data {
-                                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671940427, :text "or", :id "xzgsO1FWnO"}
-                                 "T" {
-                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "bD8Vf0YG-iE"
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":border", :id "cYpHc1d8S7"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "\"1px solid #ddd", :id "s2pX1IabjJ"}
+                                }
+                               }
+                               "x" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "jgWbg9rbVpA"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671903479, :text ":min-width", :id "To4fds_9gIy"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671932876, :id "N9a0Ziyry"
                                   :data {
-                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":height", :id "SoAym9661pn"}
-                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "W_rFxbKpT7i"}
+                                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671935197, :text "or", :id "w-pL4kO8Xw"}
+                                   "T" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "2ikB4H4BF2k"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":width", :id "i1S_nwbSmqn"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "BxnBqnHoSuK"}
+                                    }
+                                   }
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671937746, :text "240", :id "bMkvreDze"}
                                   }
                                  }
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671941927, :text "60", :id "C_Fzky4HQE"}
                                 }
                                }
-                              }
-                             }
-                             "yT" {
-                              :type :expr, :by "root", :at 1554145425540, :id "UodlKCCKB"
-                              :data {
-                               "T" {:type :leaf, :by "root", :at 1554145428021, :text ":position", :id "UodlKCCKBleaf"}
-                               "j" {:type :leaf, :by "root", :at 1554145429603, :text ":relative", :id "oT4NhVnMh9"}
+                               "y" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "sZvPiyvtP04"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671905455, :text ":min-height", :id "6EkiYviXbHO"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1552671939151, :id "WcpTGos80j"
+                                  :data {
+                                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671940427, :text "or", :id "xzgsO1FWnO"}
+                                   "T" {
+                                    :type :expr, :by "B1y7Rc-Zz", :at 1552671841457, :id "bD8Vf0YG-iE"
+                                    :data {
+                                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text ":height", :id "SoAym9661pn"}
+                                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671841457, :text "template", :id "W_rFxbKpT7i"}
+                                    }
+                                   }
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552671941927, :text "60", :id "C_Fzky4HQE"}
+                                  }
+                                 }
+                                }
+                               }
+                               "yT" {
+                                :type :expr, :by "root", :at 1554145425540, :id "UodlKCCKB"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1554145428021, :text ":position", :id "UodlKCCKBleaf"}
+                                 "j" {:type :leaf, :by "root", :at 1554145429603, :text ":relative", :id "oT4NhVnMh9"}
+                                }
+                               }
                               }
                              }
                             }
@@ -16134,77 +16141,84 @@
                         :data {
                          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":style", :id "yrwFO3vNrt"}
                          "j" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "nTFpq7EGJh"
+                          :type :expr, :by "B1y7Rc-Zz", :at 1555865897458, :id "-Ntj0u5_XK"
                           :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "{}", :id "AWevZGogVy"}
-                           "j" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "swefFC5ORp"
+                           "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555865898393, :text "merge", :id "hgGzMC3lr"}
+                           "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1555865900058, :text "ui/column", :id "TGPf7CRNV8"}
+                           "T" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "nTFpq7EGJh"
                             :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":background-color", :id "6E1OtMDzAq"}
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "{}", :id "AWevZGogVy"}
                              "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "urrGZFyNsY"
+                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "swefFC5ORp"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "hsl", :id "MTjPbJXyP0"}
-                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "0", :id "PaAVVpFr47"}
-                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "0", :id "EbggvD0Eu0"}
-                               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "100", :id "ql7vMqLVY-"}
-                               "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1551525636048, :text "1", :id "MJxkdNSHlc"}
-                              }
-                             }
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "lqZsBiwIi0R"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":width", :id "bTHaTwOnTIg"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "6FkD5TxB-HO"
-                              :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "or", :id "POzYWKOdY0-"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":background-color", :id "6E1OtMDzAq"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "4615xrFHV-i"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "urrGZFyNsY"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":width", :id "ImZymwan9NZ"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550988501211, :text "template", :id "1gk70Z_8c41"}
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "hsl", :id "MTjPbJXyP0"}
+                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "0", :id "PaAVVpFr47"}
+                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "0", :id "EbggvD0Eu0"}
+                                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "100", :id "ql7vMqLVY-"}
+                                 "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1551525636048, :text "1", :id "MJxkdNSHlc"}
                                 }
                                }
-                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "\"100%", :id "GdiKkIROHoA"}
                               }
                              }
-                            }
-                           }
-                           "v" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "wj4uosm3h5j"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":height", :id "ORHE9MZdkB7"}
-                             "j" {
-                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "myyAkKZVzFL"
+                             "r" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "lqZsBiwIi0R"
                               :data {
-                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "or", :id "3dL8KehEDvG"}
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":width", :id "bTHaTwOnTIg"}
                                "j" {
-                                :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "Tblv26DEb_g"
+                                :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "6FkD5TxB-HO"
                                 :data {
-                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":height", :id "6OV08dafMe2"}
-                                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550988504624, :text "template", :id "14mByeP4opE"}
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "or", :id "POzYWKOdY0-"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "4615xrFHV-i"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":width", :id "ImZymwan9NZ"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550988501211, :text "template", :id "1gk70Z_8c41"}
+                                  }
+                                 }
+                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "\"100%", :id "GdiKkIROHoA"}
                                 }
                                }
-                               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "\"100%", :id "lAY24_-_ynQ"}
                               }
                              }
-                            }
-                           }
-                           "x" {
-                            :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "ozXwcesjFy-"
-                            :data {
-                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":margin", :id "xMJXj2iWS0Z"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":auto", :id "0KorZEIiZqr"}
-                            }
-                           }
-                           "y" {
-                            :type :expr, :by "root", :at 1554145385589, :id "6qDGifizG"
-                            :data {
-                             "T" {:type :leaf, :by "root", :at 1554145387597, :text ":position", :id "6qDGifizGleaf"}
-                             "j" {:type :leaf, :by "root", :at 1554145389147, :text ":relative", :id "IiCuVJHsuD"}
+                             "v" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "wj4uosm3h5j"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":height", :id "ORHE9MZdkB7"}
+                               "j" {
+                                :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "myyAkKZVzFL"
+                                :data {
+                                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "or", :id "3dL8KehEDvG"}
+                                 "j" {
+                                  :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "Tblv26DEb_g"
+                                  :data {
+                                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":height", :id "6OV08dafMe2"}
+                                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550988504624, :text "template", :id "14mByeP4opE"}
+                                  }
+                                 }
+                                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text "\"100%", :id "lAY24_-_ynQ"}
+                                }
+                               }
+                              }
+                             }
+                             "x" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1550977958299, :id "ozXwcesjFy-"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":margin", :id "xMJXj2iWS0Z"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550977958299, :text ":auto", :id "0KorZEIiZqr"}
+                              }
+                             }
+                             "y" {
+                              :type :expr, :by "root", :at 1554145385589, :id "6qDGifizG"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1554145387597, :text ":position", :id "6qDGifizGleaf"}
+                               "j" {:type :leaf, :by "root", :at 1554145389147, :text ":relative", :id "IiCuVJHsuD"}
+                              }
+                             }
                             }
                            }
                           }

--- a/calcit.edn
+++ b/calcit.edn
@@ -4982,6 +4982,21 @@
           }
          }
         }
+        "yyyv" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692872373, :id "G7MS1I28HO"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692872373, :text "[]", :id "Nh6PtEWeQY"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692872373, :text "composer.comp.operations", :id "Y6F9YTw-h1"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692872373, :text ":refer", :id "VBozsdHa2t"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692872373, :id "Ef_hM8IMg6"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692872373, :text "[]", :id "3On1rdkH6S"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692872373, :text "comp-operations", :id "AYYUNAfZlp"}
+           }
+          }
+         }
+        }
        }
       }
       "x" {
@@ -5379,38 +5394,39 @@
             }
            }
            "T" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548694472794, :id "Z1GltwHax"
+            :type :expr, :by "B1y7Rc-Zz", :at 1555692409474, :id "IHvZ2yhtv"
             :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694473588, :text "div", :id "lsGRw_91uc"}
+             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692411058, :text "div", :id "iLA1sVE6P"}
              "L" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548694473828, :id "FG7nk2BAHF"
+              :type :expr, :by "B1y7Rc-Zz", :at 1555692411333, :id "NYrFfOaPOc"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694475011, :text "{}", :id "4-wP2J55ou"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692411756, :text "{}", :id "iKjD97hjbZ"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548694475803, :id "_oO8X32TZc"
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692417430, :id "S2vsq9Dsdk"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694476551, :text ":style", :id "0exLZWmAw"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text ":style", :id "vQhoZ-yne-"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548694480988, :id "_kXDiJbNML"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692417430, :id "kMYn5lsJ_I"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617250965, :text "merge", :id "N23vz1hyii"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617252586, :text "ui/flex", :id "7XrjgTvW88"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text "merge", :id "-Y3FaxMW7V"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text "ui/flex", :id "26Fasscavm"}
+                   "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692426777, :text "ui/row", :id "GsOfa12E0-"}
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1549617254471, :id "fe4fwGsUDP"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555692417430, :id "2PeDaDP4H4"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617255386, :text "{}", :id "zBkYQ854o"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text "{}", :id "WR0Feycyy4"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1549617255660, :id "7k-FbLlkXa"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555692417430, :id "UqEMzqQjbo"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617540988, :text ":overflow", :id "iDkAlSqv3"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617259257, :text ":auto", :id "l3SEMNIM7-"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text ":overflow", :id "h3ypCPuQb4"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text ":auto", :id "6IIsMrj4YE"}
                       }
                      }
                      "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1550410135867, :id "F6gMvrhgv4"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555692417430, :id "dR4YIsfo9y"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550410137315, :text ":padding", :id "F6gMvrhgv4leaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550410138688, :text "8", :id "NWClNvMpsW"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text ":padding", :id "MDuAvKvdUs"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692417430, :text "8", :id "L7mdMpn6a9"}
                       }
                      }
                     }
@@ -5421,448 +5437,486 @@
                }
               }
              }
-             "P" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548694509686, :id "evWx5AyDQ"
+             "T" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548694472794, :id "Z1GltwHax"
               :data {
-               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694516791, :text "cursor->", :id "UEaCfojNZo"}
-               "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747336001, :text ":type", :id "u9ccidoczg"}
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747366907, :text "comp-type-picker", :id "evWx5AyDQleaf"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694526358, :text "states", :id "ylinbwYhZ"}
-               "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197247975, :text "template-id", :id "YrkgOk074"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694553185, :text "focused-path", :id "px3NJJVzm"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694655410, :text "child", :id "hZ-R6QSEg"}
+               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694473588, :text "div", :id "lsGRw_91uc"}
+               "L" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548694473828, :id "FG7nk2BAHF"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694475011, :text "{}", :id "4-wP2J55ou"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692442148, :id "Df4CzmBuay"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692443369, :text ":style", :id "HSuqSEBkWJ"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692445651, :text "ui/expand", :id "OCgaqH0j07"}
+                  }
+                 }
+                }
+               }
+               "P" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548694509686, :id "evWx5AyDQ"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694516791, :text "cursor->", :id "UEaCfojNZo"}
+                 "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747336001, :text ":type", :id "u9ccidoczg"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747366907, :text "comp-type-picker", :id "evWx5AyDQleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694526358, :text "states", :id "ylinbwYhZ"}
+                 "n" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197247975, :text "template-id", :id "YrkgOk074"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694553185, :text "focused-path", :id "px3NJJVzm"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548694655410, :text "child", :id "hZ-R6QSEg"}
+                }
+               }
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548747325792, :id "A9TS3hbfG"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747331483, :text "cursor->", :id "A9TS3hbfGleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747389751, :text ":layout", :id "fZJDodmwR"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747393276, :text "comp-layout-picker", :id "lEiXzIgjkM"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747417878, :text "states", :id "KtoxZDJTFz"}
+                 "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197253431, :text "template-id", :id "QKZAPVVnG5"}
+                 "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747426661, :text "focused-path", :id "1wf9waUoAleaf"}
+                 "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747427449, :text "child", :id "DHlaVauK7w"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1549558232779, :id "_d9zniNtaO"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1549558234006, :text "when", :id "YRr9yWkgGF"}
+                 "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1549558237213, :text "config/dev?", :id "21JUW_aL0D"}
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548747667723, :id "Eb6aIrpxv"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747671063, :text "comp-inspect", :id "Eb6aIrpxvleaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747674831, :text "\"Node", :id "o1EuzEQLj"}
+                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747677230, :text "child", :id "LNq_JeAGiE"}
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548747678223, :id "k0RO-jCdOD"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747678508, :text "{}", :id "bvGhHkXD5"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1549195644640, :id "HHsL_R6kh"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195648594, :text ":bottom", :id "wyswjHoKxT"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195649214, :text "0", :id "nVE25PABbe"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1549195621962, :id "XkjjBBI0Y"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195624033, :text "cursor->", :id "XkjjBBI0Yleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195625987, :text ":presets", :id "85cqDHM0qP"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195841426, :text "comp-presets", :id "FSsPA2F3c"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195631745, :text "states", :id "m7rvKsaoK"}
+                 "w" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549197274024, :id "eKNAyqUYMH"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197269893, :text ":presets", :id "-J-Fmw4ljn"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197276081, :text "child", :id "kAFQk09er"}
+                  }
+                 }
+                 "xD" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197272986, :text "template-id", :id "04mXJArtms"}
+                 "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197195300, :text "focused-path", :id "H7xDNsJZ7V"}
+                }
+               }
+               "vT" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "CTOFHbrf9Z"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "cursor->", :id "jXU5OogFXK"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":props", :id "U9QJWY4ngF"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "comp-dict-editor", :id "4OfzwoYfS_"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "states", :id "th7wWnRJKM"}
+                 "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618078712, :text "\"Props:", :id "_qIh_qIqZO"}
+                 "x" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "NR1MHPE4x2"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":props", :id "6FE1sw5kAa"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "child", :id "TI5tkYYHt7"}
+                  }
+                 }
+                 "xT" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1554620084848, :id "ovNRDz6Yk"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620086852, :text "get", :id "WCSuNHDos"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692734855, :text "schema/props-hints", :id "Dg7GoNjUc"}
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1554620098057, :id "2anAQ4SCaJ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620118777, :text ":type", :id "JIGsGI-dL"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620120023, :text "child", :id "yAdKltTF97"}
+                    }
+                   }
+                  }
+                 }
+                 "y" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "rtLklAarXHe"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "fn", :id "XL2Swu1yw8l"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RUath5ZEutr"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "XhN1P66ALtv"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "fVpDl_cGZlZ"}
+                     "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975675700, :text "m!", :id "Vkr5i_skX"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "F0sIdXCNgx3"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "23tCzEgN0Bt"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":template/node-props", :id "-hpguciGo8h"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "GPLU2fESZrW"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "merge", :id "8phyefDGOjZ"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "VGaZ84MWPf9"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "{}", :id "HCiXTnR3EWz"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RZZ3HYXtDa7"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":template-id", :id "SNdIAwdQLe9"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "template-id", :id "oKQOUGrKd-Z"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "oa6uvtG6Asc"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":path", :id "CGpnntq81ON"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "focused-path", :id "uJ7XREdBnfv"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "4oYs55zPX5d"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "vj" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "0qfionz-2"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "cursor->", :id "jXU5OogFXK"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152977532, :text ":event", :id "U9QJWY4ngF"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "comp-dict-editor", :id "4OfzwoYfS_"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "states", :id "th7wWnRJKM"}
+                 "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152985359, :text "\"Event:", :id "_qIh_qIqZO"}
+                 "x" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "NR1MHPE4x2"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152987913, :text ":event", :id "6FE1sw5kAa"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "child", :id "TI5tkYYHt7"}
+                  }
+                 }
+                 "xT" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620137960, :text "nil", :id "Zx3mnmUJh2"}
+                 "y" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "rtLklAarXHe"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "fn", :id "XL2Swu1yw8l"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RUath5ZEutr"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "XhN1P66ALtv"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "fVpDl_cGZlZ"}
+                     "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975675700, :text "m!", :id "Vkr5i_skX"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "F0sIdXCNgx3"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "23tCzEgN0Bt"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152992567, :text ":template/node-event", :id "-hpguciGo8h"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "GPLU2fESZrW"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "merge", :id "8phyefDGOjZ"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "VGaZ84MWPf9"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "{}", :id "HCiXTnR3EWz"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RZZ3HYXtDa7"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":template-id", :id "SNdIAwdQLe9"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "template-id", :id "oKQOUGrKd-Z"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "oa6uvtG6Asc"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":path", :id "CGpnntq81ON"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "focused-path", :id "uJ7XREdBnfv"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "4oYs55zPX5d"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "w" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1549977545737, :id "hp6lIgVSo"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "cursor->", :id "A2WhM-Qiy5"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":attrs", :id "Kcjtr-qBVC"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "comp-dict-editor", :id "8MDDvUgp1Y"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "states", :id "bhWqb-Wg8w"}
+                 "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618085479, :text "\"Attrs:", :id "KBPPhrcEn9"}
+                 "y" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "l8J2GpMMUg"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":attrs", :id "bNx_OKfdCG"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "child", :id "Id_dHgtApkC"}
+                  }
+                 }
+                 "yD" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620140939, :text "nil", :id "4338p0kySA"}
+                 "yT" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "87SNmp9T9ZD"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "fn", :id "4fJA6PtvG1-"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "OPbZq-tjMQt"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "change", :id "2VcTuqRtx7g"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "d!", :id "KeMNEr-5NUz"}
+                     "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975666605, :text "m!", :id "psVS0DDkBn"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "-1ZVO_Ll0NO"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "d!", :id "XicS5U4ymdO"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":template/node-attrs", :id "FDUUGOLx8tD"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "5bgLiszcJAR"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "merge", :id "Y4mwJuze-BP"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "fLvwRFq7Fn9"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "{}", :id "HAyKNIxCEGI"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "IMgoX-IHwg9"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":template-id", :id "gDq7Mbntlwj"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "template-id", :id "EQG0RehcsOp"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "xUORgMVvQOr"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":path", :id "kfRyuGB0MQ-"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "focused-path", :id "JGTmuIpIyW2"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "change", :id "kUFMV2ny1SM"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "x" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1549210576786, :id "iCytIrskm"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210578188, :text "cursor->", :id "iCytIrskmleaf"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210580318, :text ":style", :id "RxXJBCsjm8"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210602276, :text "comp-dict-editor", :id "vipGBe7QKD"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210604059, :text "states", :id "q97jM9M2Q"}
+                 "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618090451, :text "\"Style:", :id "17_R1_v7C4"}
+                 "x" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549210605108, :id "WKAyfntJ90"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210605911, :text ":style", :id "bX7IHbA_w"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210606528, :text "child", :id "xOelK-AXqr"}
+                  }
+                 }
+                 "xT" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620143551, :text "nil", :id "FkqcInhcuI"}
+                 "y" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1549210609602, :id "ABgoKUO_I"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210611423, :text "fn", :id "ABgoKUO_Ileaf"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549210611680, :id "OxAbvuNGi4"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210812473, :text "change", :id "LplwiEAb3"}
+                     "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210620792, :text "d!", :id "kkFsSEHuzY"}
+                     "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975670615, :text "m!", :id "m9Lddj8yCe"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1549210621393, :id "xZ-Nx3KqDj"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212025130, :text "d!", :id "xZ-Nx3KqDjleaf"}
+                     "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212034329, :text ":template/node-style", :id "7UN7umiR6"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1549212037427, :id "rt1cYCdrg"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212039397, :text "merge", :id "z0QjYURZi"}
+                       "L" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1549212044572, :id "DpHb5HSlw"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212043354, :text "{}", :id "m_pPA9YRK"}
+                         "j" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549212045380, :id "Z-5YYE9-CN"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212048785, :text ":template-id", :id "YyZcJCTwn8"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212051818, :text "template-id", :id "bj_edKsIav"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1549212052422, :id "7WR3Pwdhvc"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212053216, :text ":path", :id "7WR3Pwdhvcleaf"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212063876, :text "focused-path", :id "J1TvMIgc1D"}
+                          }
+                         }
+                        }
+                       }
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212042426, :text "change", :id "llb6Bx1v6F"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
               }
              }
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548747325792, :id "A9TS3hbfG"
+              :type :expr, :by "B1y7Rc-Zz", :at 1555692430808, :id "TBgtAdGgWB"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747331483, :text "cursor->", :id "A9TS3hbfGleaf"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747389751, :text ":layout", :id "fZJDodmwR"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747393276, :text "comp-layout-picker", :id "lEiXzIgjkM"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747417878, :text "states", :id "KtoxZDJTFz"}
-               "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197253431, :text "template-id", :id "QKZAPVVnG5"}
-               "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747426661, :text "focused-path", :id "1wf9waUoAleaf"}
-               "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747427449, :text "child", :id "DHlaVauK7w"}
-              }
-             }
-             "l" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1553016411779, :id "qMVXAOPCES"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "cursor->", :id "-9ruqh5oaW"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text ":font-color", :id "SQ14d3nk6a"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "comp-font-picker", :id "dx50sD3U53"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "states", :id "ft8X_c5oH6"}
-               "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "template-id", :id "RmylztEsS1"}
-               "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "focused-path", :id "-gmB4j5l7H"}
-               "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "child", :id "7qersllpM6"}
-               "yj" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1553016411779, :id "fKLw2a8Y_X"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text ":colors", :id "0RZc2DGeF-"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553016411779, :text "settings", :id "KlChSweVBu"}
-                }
-               }
-              }
-             }
-             "n" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548958459693, :id "oZiS7VC0f"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548958461549, :text "cursor->", :id "oZiS7VC0fleaf"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548958466070, :text ":background", :id "Cvz4rpD7dd"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548958475075, :text "comp-bg-picker", :id "EIc4WJmku"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548958476698, :text "states", :id "BUybbcKuDU"}
-               "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197255233, :text "template-id", :id "kaY_VDzXtR"}
-               "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1548958484965, :text "focused-path", :id "vmgMbpzFxz"}
-               "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1548958487879, :text "child", :id "Uce_mRxoL"}
-               "yj" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552790637876, :id "kD7DFWTNbA"
-                :data {
-                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1552790640255, :text ":colors", :id "0OXE8lJYTY"}
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552790585527, :text "settings", :id "xHtAA6S40I"}
-                }
-               }
-              }
-             }
-             "r" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1549558232779, :id "_d9zniNtaO"
-              :data {
-               "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1549558234006, :text "when", :id "YRr9yWkgGF"}
-               "L" {:type :leaf, :by "B1y7Rc-Zz", :at 1549558237213, :text "config/dev?", :id "21JUW_aL0D"}
-               "T" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548747667723, :id "Eb6aIrpxv"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747671063, :text "comp-inspect", :id "Eb6aIrpxvleaf"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747674831, :text "\"Node", :id "o1EuzEQLj"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747677230, :text "child", :id "LNq_JeAGiE"}
-                 "v" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548747678223, :id "k0RO-jCdOD"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747678508, :text "{}", :id "bvGhHkXD5"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1549195644640, :id "HHsL_R6kh"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195648594, :text ":bottom", :id "wyswjHoKxT"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195649214, :text "0", :id "nVE25PABbe"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "v" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1549195621962, :id "XkjjBBI0Y"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195624033, :text "cursor->", :id "XkjjBBI0Yleaf"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195625987, :text ":presets", :id "85cqDHM0qP"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195841426, :text "comp-presets", :id "FSsPA2F3c"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549195631745, :text "states", :id "m7rvKsaoK"}
-               "w" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549197274024, :id "eKNAyqUYMH"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197269893, :text ":presets", :id "-J-Fmw4ljn"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197276081, :text "child", :id "kAFQk09er"}
-                }
-               }
-               "xD" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197272986, :text "template-id", :id "04mXJArtms"}
-               "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1549197195300, :text "focused-path", :id "H7xDNsJZ7V"}
-              }
-             }
-             "v5" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1550944543258, :id "Kucags-xgJ"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944544828, :text "=<", :id "Kucags-xgJleaf"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944546311, :text "nil", :id "apCGaLagSw"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944547050, :text "8", :id "rjM5b8TDXO"}
-              }
-             }
-             "v9" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1551375630345, :id "D30BAGezl2"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551375630345, :text "cursor->", :id "AeBMLQpRve"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551375630345, :text ":mocks", :id "DsmKfWswxl"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551375630345, :text "comp-mock-picker", :id "79SG90e4eg"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1551375630345, :text "states", :id "aLYug34UbH"}
-               "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1551375630345, :text "template", :id "z4EmDANGj8"}
-              }
-             }
-             "vD" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1550944533937, :id "n3thKa-Yr1"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944533937, :text "pre", :id "4hPAWeI51D"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692429899, :text "div", :id "JI8o3DPuK"}
                "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550944533937, :id "i0fKZ2-fSc"
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692431168, :id "Oq2riD8nck"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944533937, :text "{}", :id "iiv1s9870Q"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692431612, :text "{}", :id "87RiIcxTF-"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550944533937, :id "QNqVfcvgAS"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692432722, :id "85FiB4Zx2W"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944533937, :text ":inner-text", :id "5YK-WMDx6h"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692435772, :text ":style", :id "AGrF09HmL"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692438791, :text "ui/expand", :id "IUj8WmGLqE"}
+                  }
+                 }
+                }
+               }
+               "l" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692601394, :id "MYs68R9VwR"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692601394, :text "cursor->", :id "WwN1EtsbXi"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692601394, :text ":mocks", :id "Fa8OsyzEn7"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692601394, :text "comp-mock-picker", :id "yWdoQUUoIW"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692601394, :text "states", :id "lPJ4zb07D8"}
+                 "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692601394, :text "template", :id "T1i1nYdu45"}
+                }
+               }
+               "n" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692582056, :id "rJc3_mCSFB"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text "pre", :id "L6CMo2_BEV"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692582056, :id "ZVs5khadWi"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text "{}", :id "PKXIwnJ9Ey"}
                    "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550944533937, :id "9kzWlKM3g8"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555692582056, :id "B8cDDe08SX"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226759295, :text "write-edn", :id "ql8SmjbQd7"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944533937, :text "mock-data", :id "NXMaglkBfv"}
-                    }
-                   }
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550944533937, :id "pHAn0lGVvL"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944533937, :text ":style", :id "b2AmnrNRBQ"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550944533937, :text "style-mock-data", :id "RtNMrRhf6I"}
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "vL" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552193538511, :id "eHlPXM6gdo"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193538511, :text "comp-props-hint", :id "45_ZNEguNB"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1552193538511, :id "kjR9XwRCN4"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193538511, :text ":type", :id "iYc3zaKxPa"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193538511, :text "child", :id "g2dtiN3tX7"}
-                }
-               }
-              }
-             }
-             "vT" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "CTOFHbrf9Z"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "cursor->", :id "jXU5OogFXK"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":props", :id "U9QJWY4ngF"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "comp-dict-editor", :id "4OfzwoYfS_"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "states", :id "th7wWnRJKM"}
-               "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618078712, :text "\"Props:", :id "_qIh_qIqZO"}
-               "x" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "NR1MHPE4x2"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":props", :id "6FE1sw5kAa"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "child", :id "TI5tkYYHt7"}
-                }
-               }
-               "xT" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1554620084848, :id "ovNRDz6Yk"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620086852, :text "get", :id "WCSuNHDos"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620095298, :text "props-hints", :id "Dg7GoNjUc"}
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1554620098057, :id "2anAQ4SCaJ"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620118777, :text ":type", :id "JIGsGI-dL"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620120023, :text "child", :id "yAdKltTF97"}
-                  }
-                 }
-                }
-               }
-               "y" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "rtLklAarXHe"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "fn", :id "XL2Swu1yw8l"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RUath5ZEutr"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "XhN1P66ALtv"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "fVpDl_cGZlZ"}
-                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975675700, :text "m!", :id "Vkr5i_skX"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "F0sIdXCNgx3"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "23tCzEgN0Bt"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":template/node-props", :id "-hpguciGo8h"}
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "GPLU2fESZrW"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "merge", :id "8phyefDGOjZ"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text ":inner-text", :id "M60naL7CY2"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "VGaZ84MWPf9"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1555692582056, :id "r9LeI-pOI5"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "{}", :id "HCiXTnR3EWz"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RZZ3HYXtDa7"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":template-id", :id "SNdIAwdQLe9"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "template-id", :id "oKQOUGrKd-Z"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "oa6uvtG6Asc"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":path", :id "CGpnntq81ON"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "focused-path", :id "uJ7XREdBnfv"}
-                        }
-                       }
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text "write-edn", :id "3rxiJsRBRc"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text "mock-data", :id "Mx0bXMhpuN"}
                       }
                      }
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "4oYs55zPX5d"}
                     }
                    }
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "vj" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "0qfionz-2"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "cursor->", :id "jXU5OogFXK"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152977532, :text ":event", :id "U9QJWY4ngF"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "comp-dict-editor", :id "4OfzwoYfS_"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "states", :id "th7wWnRJKM"}
-               "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152985359, :text "\"Event:", :id "_qIh_qIqZO"}
-               "x" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "NR1MHPE4x2"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152987913, :text ":event", :id "6FE1sw5kAa"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "child", :id "TI5tkYYHt7"}
-                }
-               }
-               "xT" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620137960, :text "nil", :id "Zx3mnmUJh2"}
-               "y" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "rtLklAarXHe"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "fn", :id "XL2Swu1yw8l"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RUath5ZEutr"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "XhN1P66ALtv"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "fVpDl_cGZlZ"}
-                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975675700, :text "m!", :id "Vkr5i_skX"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "F0sIdXCNgx3"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "d!", :id "23tCzEgN0Bt"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552152992567, :text ":template/node-event", :id "-hpguciGo8h"}
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "GPLU2fESZrW"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1555692582056, :id "fbpIDNd3zL"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "merge", :id "8phyefDGOjZ"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "VGaZ84MWPf9"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "{}", :id "HCiXTnR3EWz"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "RZZ3HYXtDa7"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":template-id", :id "SNdIAwdQLe9"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "template-id", :id "oKQOUGrKd-Z"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549618018520, :id "oa6uvtG6Asc"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text ":path", :id "CGpnntq81ON"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "focused-path", :id "uJ7XREdBnfv"}
-                        }
-                       }
-                      }
-                     }
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618018520, :text "change", :id "4oYs55zPX5d"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text ":style", :id "ZVShBnFYEz"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692582056, :text "style-mock-data", :id "-4qp6sK2d7"}
                     }
                    }
                   }
                  }
                 }
                }
-              }
-             }
-             "w" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1549977545737, :id "hp6lIgVSo"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "cursor->", :id "A2WhM-Qiy5"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":attrs", :id "Kcjtr-qBVC"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "comp-dict-editor", :id "8MDDvUgp1Y"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "states", :id "bhWqb-Wg8w"}
-               "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618085479, :text "\"Attrs:", :id "KBPPhrcEn9"}
-               "y" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "l8J2GpMMUg"
+               "p" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692586859, :id "A76mu58n9_"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":attrs", :id "bNx_OKfdCG"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "child", :id "Id_dHgtApkC"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692586859, :text "=<", :id "VS1NVKzFMk"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692586859, :text "nil", :id "5EhSxWx42G"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692586859, :text "8", :id "OOHvP6a2MJ"}
                 }
                }
-               "yD" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620140939, :text "nil", :id "4338p0kySA"}
-               "yT" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "87SNmp9T9ZD"
+               "q" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692635305, :id "KfsGdeMLuW"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "fn", :id "4fJA6PtvG1-"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692635305, :text "comp-props-hint", :id "ulOb0KeeAr"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "OPbZq-tjMQt"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692635305, :id "qT1VNY4Tno"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "change", :id "2VcTuqRtx7g"}
-                   "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "d!", :id "KeMNEr-5NUz"}
-                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975666605, :text "m!", :id "psVS0DDkBn"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "-1ZVO_Ll0NO"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "d!", :id "XicS5U4ymdO"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":template/node-attrs", :id "FDUUGOLx8tD"}
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "5bgLiszcJAR"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "merge", :id "Y4mwJuze-BP"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "fLvwRFq7Fn9"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "{}", :id "HAyKNIxCEGI"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "IMgoX-IHwg9"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":template-id", :id "gDq7Mbntlwj"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "template-id", :id "EQG0RehcsOp"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549618013002, :id "xUORgMVvQOr"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text ":path", :id "kfRyuGB0MQ-"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "focused-path", :id "JGTmuIpIyW2"}
-                        }
-                       }
-                      }
-                     }
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618013002, :text "change", :id "kUFMV2ny1SM"}
-                    }
-                   }
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692635305, :text ":type", :id "mUlpkJsqKU"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692635305, :text "child", :id "iis_FQXX04"}
                   }
                  }
                 }
                }
-              }
-             }
-             "x" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1549210576786, :id "iCytIrskm"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210578188, :text "cursor->", :id "iCytIrskmleaf"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210580318, :text ":style", :id "RxXJBCsjm8"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210602276, :text "comp-dict-editor", :id "vipGBe7QKD"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210604059, :text "states", :id "q97jM9M2Q"}
-               "w" {:type :leaf, :by "B1y7Rc-Zz", :at 1549618090451, :text "\"Style:", :id "17_R1_v7C4"}
-               "x" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549210605108, :id "WKAyfntJ90"
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692490310, :id "zYglRrwe3c"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210605911, :text ":style", :id "bX7IHbA_w"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210606528, :text "child", :id "xOelK-AXqr"}
-                }
-               }
-               "xT" {:type :leaf, :by "B1y7Rc-Zz", :at 1554620143551, :text "nil", :id "FkqcInhcuI"}
-               "y" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1549210609602, :id "ABgoKUO_I"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210611423, :text "fn", :id "ABgoKUO_Ileaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549210611680, :id "OxAbvuNGi4"
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "cursor->", :id "0jN4OxxYpI"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text ":font-color", :id "eOlBK8CVuL"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "comp-font-picker", :id "V0euyW9J0L"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "states", :id "MEgT-gmWBU"}
+                 "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "template-id", :id "l1a06gnU7-"}
+                 "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "focused-path", :id "mw6qqGZHvh"}
+                 "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "child", :id "xtCE4sXDVP"}
+                 "yj" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692490310, :id "fEXmPspsuM"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210812473, :text "change", :id "LplwiEAb3"}
-                   "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1549210620792, :text "d!", :id "kkFsSEHuzY"}
-                   "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1549975670615, :text "m!", :id "m9Lddj8yCe"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text ":colors", :id "huOBp8A7mr"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692490310, :text "settings", :id "UKHPEdlKeD"}
                   }
                  }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1549210621393, :id "xZ-Nx3KqDj"
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1555692499332, :id "Eq8ru71yZc"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "cursor->", :id "iSBqq0WR4P"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text ":background", :id "whWAVrRjyC"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "comp-bg-picker", :id "lJjBhzw6Zr"}
+                 "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "states", :id "ZPCt5_kdSF"}
+                 "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "template-id", :id "qSVhvKoq0O"}
+                 "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "focused-path", :id "-YmlhxnDSu"}
+                 "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "child", :id "ZKd5OU-tYA"}
+                 "yj" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555692499332, :id "oztV098q6U"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212025130, :text "d!", :id "xZ-Nx3KqDjleaf"}
-                   "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212034329, :text ":template/node-style", :id "7UN7umiR6"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1549212037427, :id "rt1cYCdrg"
-                    :data {
-                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212039397, :text "merge", :id "z0QjYURZi"}
-                     "L" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1549212044572, :id "DpHb5HSlw"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212043354, :text "{}", :id "m_pPA9YRK"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549212045380, :id "Z-5YYE9-CN"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212048785, :text ":template-id", :id "YyZcJCTwn8"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212051818, :text "template-id", :id "bj_edKsIav"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1549212052422, :id "7WR3Pwdhvc"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212053216, :text ":path", :id "7WR3Pwdhvcleaf"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212063876, :text "focused-path", :id "J1TvMIgc1D"}
-                        }
-                       }
-                      }
-                     }
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549212042426, :text "change", :id "llb6Bx1v6F"}
-                    }
-                   }
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text ":colors", :id "yd1vBwdtJr"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692499332, :text "settings", :id "6ntiqtulU1"}
                   }
                  }
                 }
@@ -5903,7 +5957,7 @@
               :type :expr, :by "B1y7Rc-Zz", :at 1553227324558, :id "QFLp0LrC-"
               :data {
                "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227336055, :text "->>", :id "RKu1fzuWyM"}
-               "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227359405, :text "node-layouts", :id "pjp1ttvf2"}
+               "b" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692763703, :text "schema/node-layouts", :id "pjp1ttvf2"}
                "f" {
                 :type :expr, :by "B1y7Rc-Zz", :at 1553227360055, :id "YzU0eFjreL"
                 :data {
@@ -6246,7 +6300,7 @@
                             :type :expr, :by "B1y7Rc-Zz", :at 1553227658209, :id "H2-tG_x-mn"
                             :data {
                              "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227658209, :text "->>", :id "5c3IlDTO4c"}
-                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227658209, :text "node-layouts", :id "cbQ9oopqDN"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692743518, :text "schema/node-layouts", :id "cbQ9oopqDN"}
                              "r" {
                               :type :expr, :by "B1y7Rc-Zz", :at 1553227658209, :id "kyfPQtGzfX"
                               :data {
@@ -7300,875 +7354,6 @@
        }
       }
      }
-     "comp-operations" {
-      :type :expr, :by "B1y7Rc-Zz", :at 1548610853161, :id "FmbD7ZFwkF"
-      :data {
-       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610854649, :text "defcomp", :id "G5Gr3K0Qmp"}
-       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610853161, :text "comp-operations", :id "g5QCj7peMC"}
-       "n" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1548610855494, :id "LLpirstZeM"
-        :data {
-         "5" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693649011, :text "states", :id "-89nlofTE2"}
-         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611150659, :text "template-id", :id "XDIhMQoMp"}
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610866143, :text "focused-path", :id "GcKeVt_Dp"}
-        }
-       }
-       "v" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "qncOfyqD0P"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "div", :id "aV60yOg1Z4"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "5U3JzsLX3Y"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "{}", :id "Vbr19KiFEF"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "DzhA-pX-2a"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text ":style", :id "wlgMEHEelq"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "y1xEqDLo6b"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "merge", :id "USAw8uU9zn"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617983250, :text "ui/row", :id "QPPljxwBza"}
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "3xZjQbA64R"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "{}", :id "TpsIKAc_y_"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1551549464627, :id "s-t3mJjNC"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551549465699, :text ":padding", :id "Us9QyYYcaf"}
-                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551549697663, :text "\"0 8px", :id "5-_clryu3w"}
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "GVGNBudk6A"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "div", :id "oeGPkXVyGX4"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "8DDv1Cjl7GW"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "{}", :id "oCo_Es4Og_t"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "0UECM55ZYZF"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "<>", :id "6F4ozY9_vfm"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617987530, :text "\"Operations:", :id "b9B8GR2GdC1"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550408912242, :text "style/field-label", :id "K0dg-Cxp6O"}
-            }
-           }
-          }
-         }
-         "v" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "-nWGhIVBnZ"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "div", :id "61IWLMc4fo"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "5m24ZqfCZb"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "{}", :id "wE23PPAFqF"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548693910265, :id "73DPVN1VsX"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693911001, :text ":style", :id "Q36ZSIHtU4"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550592931725, :id "CsIdxE0BoI"
-                :data {
-                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550592934582, :text "merge", :id "2BMqFgjlhR"}
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510036397, :text "ui/flex", :id "xeroA9ykN7"}
-                }
-               }
-              }
-             }
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "YgPNY3JJ3E"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617952176, :text "a", :id "RBLOfII1IU"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "_v3v5AZQ8i"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "{}", :id "qwCEd-TyD_"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "Gl4KVjq2PO"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text ":style", :id "4j-gLs-Bph"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593008669, :text "style/link", :id "wyYycb3YI-"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "dvwkBeGJ1n"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text ":inner-text", :id "-utEcJ5MWv"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "\"Append", :id "2VPQ9sP5T4"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548610941592, :id "qTJHJ1ycm"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610944080, :text ":on-click", :id "qTJHJ1ycmleaf"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548610944394, :id "ZfKGu8choY"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610944677, :text "fn", :id "xUxeQ1iCqk"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548610944968, :id "uzC9fku9wj"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610945133, :text "e", :id "kxdat_b-Wu"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610945680, :text "d!", :id "hrazyGqfqO"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610946306, :text "m!", :id "FiEcHnovti"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548610946800, :id "7HllAyR4Ae"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610947448, :text "d!", :id "7HllAyR4Aeleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610962990, :text ":template/append-markup", :id "lPV_-WiCj"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548611134279, :id "IZ1isdn8KS"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611135870, :text "{}", :id "eqCXq3x8_"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548611136211, :id "sxXvVCdmnW"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611141335, :text ":template-id", :id "UHv0dDQCS5"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611162394, :text "template-id", :id "y0xYFiMprh"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548611143092, :id "eGHAN_FXpY"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611144567, :text ":path", :id "eGHAN_FXpYleaf"}
-                         "j" {:type :leaf, :by "root", :at 1548675042762, :text "focused-path", :id "C8aBmKB0AS"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548781907388, :id "4DUx6WFbLp"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781909657, :text "d!", :id "4DUx6WFbLpleaf"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781978406, :text ":router/move-append", :id "Ek9XnARW4R"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781915305, :text "nil", :id "HVMMnB3oy"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "s" {
-            :type :expr, :by "root", :at 1548675907462, :id "cgcmN3uSVt"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617959258, :text "a", :id "knsuDhOX8T"}
-             "j" {
-              :type :expr, :by "root", :at 1548675907462, :id "Tv0kew0i8M"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1548675907462, :text "{}", :id "Cd-oJqygeN"}
-               "j" {
-                :type :expr, :by "root", :at 1548675907462, :id "U_oUL9UFZu"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1548675907462, :text ":style", :id "LPBhXjcUI3"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593011375, :text "style/link", :id "7Aa2F29-d2"}
-                }
-               }
-               "r" {
-                :type :expr, :by "root", :at 1548675907462, :id "kHHE4ywQTJ"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1548675907462, :text ":inner-text", :id "-y7qhdEZO_"}
-                 "j" {:type :leaf, :by "root", :at 1548675914472, :text "\"After", :id "jFbr6HQJ1Z"}
-                }
-               }
-               "v" {
-                :type :expr, :by "root", :at 1548675907462, :id "h3QU1ok7D0"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1548675907462, :text ":on-click", :id "e2I087UCfi"}
-                 "j" {
-                  :type :expr, :by "root", :at 1548675907462, :id "NAgT86A1A_"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1548675907462, :text "fn", :id "LvwxP7ZYKRh"}
-                   "j" {
-                    :type :expr, :by "root", :at 1548675907462, :id "sBwcXv5qoce"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1548675907462, :text "e", :id "l34RShswpVj"}
-                     "j" {:type :leaf, :by "root", :at 1548675907462, :text "d!", :id "gcPRFa79wHK"}
-                     "r" {:type :leaf, :by "root", :at 1548675907462, :text "m!", :id "4XH7G_ElUFU"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "root", :at 1548675907462, :id "eRQqy3eOJvt"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1548675907462, :text "d!", :id "aestIlFvyt3"}
-                     "j" {:type :leaf, :by "root", :at 1548675918607, :text ":template/after-markup", :id "x8R-fsvlMdh"}
-                     "r" {
-                      :type :expr, :by "root", :at 1548675907462, :id "_E3fAQLA_E9"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1548675907462, :text "{}", :id "c3mMH9VR6MO"}
-                       "j" {
-                        :type :expr, :by "root", :at 1548675907462, :id "WWRA1A5wqkW"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1548675907462, :text ":template-id", :id "93xusauJ_5Z"}
-                         "j" {:type :leaf, :by "root", :at 1548675907462, :text "template-id", :id "DI40JSR9DFZ"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "root", :at 1548675907462, :id "50HXZnA9u58"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1548675907462, :text ":path", :id "R159VyITcsD"}
-                         "j" {:type :leaf, :by "root", :at 1548675907462, :text "focused-path", :id "ndMPhQpZL8n"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548781917876, :id "zSjYK8QRrf"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781917876, :text "d!", :id "ep1n27Ty5b"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781975739, :text ":router/move-after", :id "6nd__GVwXp"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781917876, :text "nil", :id "BZieHQeli7"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "sj" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "9nTwOcbckO"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617963206, :text "a", :id "u3oo1oQBpp"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "pndZqS79G7"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "fIVI4pYCHJ"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "LcvYSsTnIA"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":style", :id "_hYbZxT9fq"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593013539, :text "style/link", :id "FmEqWHgF7Z"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "4hPZU0Vbja"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":inner-text", :id "XKKY4jmTZ7"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693809077, :text "\"Prepend", :id "zyuC6zQF93"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "bjtoqyxbes"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":on-click", :id "gdTsS5vx6M"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "wgl7XRTYXG"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "fn", :id "zndB-T642q"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "FFNC3b3eA-"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "e", :id "Srh8Ab50KDg"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "zt_NIk_TMTV"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "m!", :id "zW9q3uVmPpP"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "DrnCGY42gdP"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "RsvI_0n74a9"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693814717, :text ":template/prepend-markup", :id "EQdw576dVF1"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "cAZiMewEhp7"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "TvZudKQB4GT"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "CjBgSMs1zrw"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":template-id", :id "3-V6yrZWKtV"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "template-id", :id "tUlHge3uyPt"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "WUWAodY_L_-"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":path", :id "39yq_mieU8y"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "focused-path", :id "saRtHRPotxA"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548781922371, :id "zPtd_3Ubdt"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781922371, :text "d!", :id "dHy-NT3JWd"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781973563, :text ":router/move-prepend", :id "9_dgjXccuw"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781922371, :text "nil", :id "eh_KsbZogq"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "sr" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "PT_MgAu2pC"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617966585, :text "a", :id "u3oo1oQBpp"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "pndZqS79G7"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "fIVI4pYCHJ"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "LcvYSsTnIA"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":style", :id "_hYbZxT9fq"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593015076, :text "style/link", :id "FmEqWHgF7Z"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "4hPZU0Vbja"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":inner-text", :id "XKKY4jmTZ7"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693880208, :text "\"Before", :id "zyuC6zQF93"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "bjtoqyxbes"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":on-click", :id "gdTsS5vx6M"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "wgl7XRTYXG"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "fn", :id "zndB-T642q"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "FFNC3b3eA-"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "e", :id "Srh8Ab50KDg"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "zt_NIk_TMTV"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "m!", :id "zW9q3uVmPpP"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "DrnCGY42gdP"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "RsvI_0n74a9"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693887397, :text ":template/before-markup", :id "EQdw576dVF1"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "cAZiMewEhp7"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "TvZudKQB4GT"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "CjBgSMs1zrw"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":template-id", :id "3-V6yrZWKtV"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "template-id", :id "tUlHge3uyPt"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "WUWAodY_L_-"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":path", :id "39yq_mieU8y"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "focused-path", :id "saRtHRPotxA"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548781930999, :id "s3qiSai1Cq"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781930999, :text "d!", :id "-TGEXrOL1m"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781954896, :text ":router/move-before", :id "satv4jK9KM"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781930999, :text "nil", :id "C2Ti7l9uay"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "w" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "hm1dT4mvir"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "cursor->", :id "Dp_c30ZEAw"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":remove", :id "6NrRsRer3c"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "comp-confirm", :id "xROU5GNsJx"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "states", :id "FQF8GxBmtg"}
-             "x" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "N0YSSrgJqy"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "{}", :id "-vmUyb02mL"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "POdDWDJqZd"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":trigger", :id "KzX3bZ4Mpq"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "UlK0VH03aF"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617970677, :text "a", :id "hgj-zGHNrx"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "fKh1CyOADH"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "{}", :id "Db_xOrQAx9"}
-                     "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "RFyQiYJiuU"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":style", :id "vnv_Ese_2QE"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617972424, :text "ui/link", :id "ldn-BvVzpar"}
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "xNGiUoUibEh"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":inner-text", :id "4gCvaLlCy0V"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "\"Remove", :id "MBgXZ_WxKlK"}
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "y" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "sy2g7vstzXn"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "fn", :id "NuB3IKUjnUf"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "gbOe3C2VHb-"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "e", :id "psgwfz0z3AP"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "d!", :id "B2Gb05ajvmE"}
-                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "m!", :id "WY2O0_MBjUb"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "Fqhb053w6Qa"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "d!", :id "gRH3pBU8xVn"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":template/remove-markup", :id "r44qn8X3Q8n"}
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "gRcTQH3k7Cy"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "{}", :id "TeMOMNziZsa"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "HNgqztgA6H6"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":template-id", :id "wxRwJiJS3E5"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "template-id", :id "2jjYZQSK39X"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "PiqtqOy3pf8"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":path", :id "nFE_Mb_VxGB"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "focused-path", :id "LThbGL7Anw5"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "OHj58P3GZ4j"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "d!", :id "AeyC87WGQzU"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989437966, :text ":session/focus-to", :id "qILXoGbfbRL"}
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550989438483, :id "cGytzB0JSN"
-                  :data {
-                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989441402, :text "{}", :id "hMB-ODI9b"}
-                   "T" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550989442157, :id "5qmZH1jEUk"
-                    :data {
-                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989449261, :text ":path", :id "W2OU2depAb"}
-                     "T" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "hau1krOldv0"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "vec", :id "BCDn60BWD_x"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "SYnYBbc_vv1"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "butlast", :id "30ipRz6m-Ja"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "focused-path", :id "QYUmFgh-9tX"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "x" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "BjjR_wL4NP"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "a", :id "inNLMR1lqa"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "9wV5fwJDWs"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "JpQF28I-VK"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6xWixEzHlL"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":style", :id "GNubpIc-FT"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593017603, :text "style/link", :id "i2YmlsvkGF"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "htClbDTKG4"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":inner-text", :id "CYLLqr8LSV"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510121203, :text "\"Wrap", :id "TMfvn-dsjL"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "4M3_BXHkOt"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":on-click", :id "etVLih8wkJ"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "jv1921JDM6"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "fn", :id "rdcsr2KTEYs"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "Bf4M9vCcHXM"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "e", :id "mJlHCoVt-J1"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "cOWl2Rw8FrA"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "m!", :id "QGGzRuHn_V4"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6bYp5YIPDCw"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "fHoLf48fgZs"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510151163, :text ":template/wrap-markup", :id "HWjGQ4Yda0w"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "vQWhxcFSYBe"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "YbjyxzFV0kQ"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "5azvXWhPNyD"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":template-id", :id "wgiqMD-zeJi"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "template-id", :id "jCHviSk0TYI"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "3o2YKieSy4N"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":path", :id "LKWtcEx9KYB"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "focused-path", :id "upvwOCui-QH"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "7czFvx4mcmd"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "YjB5-K4EvVT"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989455170, :text ":session/focus-to", :id "eUAFvDzcHjt"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1550989455737, :id "xaod74dP6j"
-                      :data {
-                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989456387, :text "{}", :id "JaXAzeh06j"}
-                       "T" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550989457962, :id "OCu7sbH8oz"
-                        :data {
-                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989458983, :text ":path", :id "MPI0sar0dF"}
-                         "T" {
-                          :type :expr, :by "B1y7Rc-Zz", :at 1550510607508, :id "dIAyEGdjkN"
-                          :data {
-                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510608178, :text "conj", :id "HoulIeTfktf"}
-                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510610181, :text "focused-path", :id "zn7-3njl4T"}
-                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510614985, :text "bisection/mid-id", :id "nMBjSAZJ35"}
-                          }
-                         }
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "y" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "fDyBEWa_N"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "a", :id "inNLMR1lqa"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "9wV5fwJDWs"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "JpQF28I-VK"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6xWixEzHlL"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":style", :id "GNubpIc-FT"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593019296, :text "style/link", :id "i2YmlsvkGF"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "htClbDTKG4"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":inner-text", :id "CYLLqr8LSV"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510138597, :text "\"Spread", :id "TMfvn-dsjL"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "4M3_BXHkOt"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":on-click", :id "etVLih8wkJ"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "jv1921JDM6"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "fn", :id "rdcsr2KTEYs"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "Bf4M9vCcHXM"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "e", :id "mJlHCoVt-J1"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "cOWl2Rw8FrA"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "m!", :id "QGGzRuHn_V4"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6bYp5YIPDCw"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "fHoLf48fgZs"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510147323, :text ":template/spread-markup", :id "HWjGQ4Yda0w"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "vQWhxcFSYBe"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "YbjyxzFV0kQ"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "5azvXWhPNyD"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":template-id", :id "wgiqMD-zeJi"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "template-id", :id "jCHviSk0TYI"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "3o2YKieSy4N"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":path", :id "LKWtcEx9KYB"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "focused-path", :id "upvwOCui-QH"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "7czFvx4mcmd"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "YjB5-K4EvVT"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":router/move-before", :id "eUAFvDzcHjt"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "nil", :id "HoulIeTfktf"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "yT" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "96gDLRxJ2K"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "a", :id "gnC04QdTZx"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "kjyigxJoSb"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "{}", :id "jtaPgJmhOF"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "5W9n9d085k"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":style", :id "DFS3ounO1V"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "style/link", :id "lieRRk5kyF"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "rsos_Sakct"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":inner-text", :id "ojXelJ2bFC"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593113046, :text "\"Copy", :id "400DNoPxvH"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "facw9jtfDe"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":on-click", :id "lqmvGeNBZk"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "RDEPl0C9ng"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "fn", :id "rcGucns-qH"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "FzyutH1ovAQ"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "e", :id "eJhahnRdFhy"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "d!", :id "W42a0C70IJi"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "m!", :id "EAwp8AP9Vv5"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "9Hxn948Da_g"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "d!", :id "c_24nUh9NbE"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550597031437, :text ":session/copy-markup", :id "ZT3C4eScok9"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "b-CUtJjI3sJ"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "{}", :id "ddgt2G7eOYT"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "-N-YozvOpkX"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":template-id", :id "l_e37mL-6B7"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "template-id", :id "kGH1zQFWGIU"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "rwRXZnHhYbr"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":path", :id "a4TBaDUjG7F"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "focused-path", :id "vOa7GVnAZXq"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "yj" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "mZwkWISGcr"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "a", :id "JabJfq5HNc"}
-             "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "R-5jkQXg-B"
-              :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "{}", :id "NbP7LHJTgH"}
-               "j" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "HYqVMqvUvB"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":style", :id "aZQc5H9VfK"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "style/link", :id "YPnO88XPBK"}
-                }
-               }
-               "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "BiVIXnDxXZ"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":inner-text", :id "lgp7-q3Wen"}
-                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593150023, :text "\"Paste", :id "RqLFwcmXkA"}
-                }
-               }
-               "v" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "05sT4bDpo5"
-                :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":on-click", :id "14CafIQBJI"}
-                 "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "Wvl-N0uHZE"
-                  :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "fn", :id "rZY_OWHSTiY"}
-                   "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "xM6SBeT39yj"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "e", :id "0Fn6-EC-sZV"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "d!", :id "4IjrV1VjUP5"}
-                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "m!", :id "_LNZMsLWrMg"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "SPMgBlNFUhL"
-                    :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "d!", :id "syhm9U0EL1W"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550597033329, :text ":session/paste-markup", :id "sA8B0mxQrgH"}
-                     "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "veMq3oEL65t"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "{}", :id "Y72lHxnQ78L"}
-                       "j" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "L7_DzoFfUCU"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":template-id", :id "YTXZ2-T1VX3"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "template-id", :id "mlYG4NERBUQ"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "cGgNtkbzbwE"
-                        :data {
-                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":path", :id "XvGAgfrK17a"}
-                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "focused-path", :id "ftXRtyjfmNf"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-          }
-         }
-        }
-       }
-      }
-     }
      "comp-props-hint" {
       :type :expr, :by "B1y7Rc-Zz", :at 1551634089480, :id "5oIpAYPK9f"
       :data {
@@ -8231,7 +7416,7 @@
               :type :expr, :by "B1y7Rc-Zz", :at 1551634204880, :id "76rww7rn-"
               :data {
                "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634205707, :text "get", :id "970UU281e_"}
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634208752, :text "props-hints", :id "anVxwuh-H"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692786309, :text "schema/props-hints", :id "anVxwuh-H"}
                "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634211518, :text "type", :id "LLwfXiGNq"}
               }
              }
@@ -8398,471 +7583,6 @@
                }
               }
              }
-            }
-           }
-          }
-         }
-        }
-       }
-      }
-     }
-     "node-layouts" {
-      :type :expr, :by "B1y7Rc-Zz", :at 1548747538542, :id "CxdQWjlEcC"
-      :data {
-       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747539532, :text "def", :id "GZcS7qeSuN"}
-       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747538542, :text "node-layouts", :id "FuGKfDyKA0"}
-       "r" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1548747538542, :id "BlGjArD8AP"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747540545, :text "[]", :id "jWx9VqGl8p"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548747541005, :id "bRdqHIzUDQ"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747541626, :text "{}", :id "T_8DPOuYhd"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548747541958, :id "mxjARIh-6C"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747543132, :text ":value", :id "X4tqIZAeMh"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747556431, :text ":row", :id "ANJpviaIOJ"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548747557380, :id "hlUIRXviOW"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747558620, :text ":display", :id "hlUIRXviOWleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747563464, :text "\"Row", :id "a1F4u2GhGu"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226225352, :id "B6WytXQzw"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226227210, :text ":kind", :id "B6WytXQzwleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226229943, :text ":row", :id "0EPMaCSujJ"}
-            }
-           }
-          }
-         }
-         "l" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1549972422842, :id "DFykNRAG7B"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text "{}", :id "R3OzoQDn2o"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1549972422842, :id "b1FbEMyqfP"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text ":value", :id "dYECnsM0uP"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text ":row-middle", :id "4W8SF-uTJe"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1549972422842, :id "PIsDY6goo-"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text ":display", :id "ro4D0zUax7"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text "\"Row Middle", :id "OAkLOXxePC"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226232161, :id "FHg252v8NF"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226233851, :text ":kind", :id "FHg252v8NFleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226235169, :text ":row", :id "VxIBii3pOY"}
-            }
-           }
-          }
-         }
-         "m" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1549972426812, :id "GbyRQ5G2To"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text "{}", :id "lznF7hSpCT"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1549972426812, :id "Fl_P_uISYo"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text ":value", :id "kJTTEZ99Zm"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text ":row-parted", :id "uWcfEuMUlA"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1549972426812, :id "TvCrDusPTX"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text ":display", :id "9-PQkfqYXd"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text "\"Row Parted", :id "FyF25oF-sH"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226236592, :id "QDQRIqOi-"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226238410, :text ":kind", :id "QDQRIqOi-leaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226240341, :text ":row", :id "QPRYEw0LI"}
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548747564797, :id "howRYt-M3"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747565712, :text "{}", :id "howRYt-M3leaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548747566048, :id "ZyURcgh5X6"
-            :data {
-             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747571030, :text ":value", :id "5vUB-bzCK"}
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747568254, :text ":column", :id "Ww4-zzE6vd"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548747571654, :id "6vn04-fQO"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747572883, :text ":display", :id "6vn04-fQOleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747574548, :text "\"Column", :id "FNZH_517kh"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226247185, :id "6l-7YanwwQ"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226248356, :text ":kind", :id "6l-7YanwwQleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226250855, :text ":column", :id "eJq32ygUK5"}
-            }
-           }
-          }
-         }
-         "yj" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1548747575584, :id "yph6t9HONE"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747576273, :text "{}", :id "jfXC6P-ajleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548747576670, :id "2XFleAIN2"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747582424, :text ":value", :id "iSw2dGddW7"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747627381, :text ":column-parted", :id "MwkYWYViE"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1548747585297, :id "h8laFjdzNW"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747587663, :text ":display", :id "h8laFjdzNWleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747631766, :text "\"Column Parted", :id "GxytUe71w8"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226253169, :id "NbthBz2F5K"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226254293, :text ":kind", :id "NbthBz2F5Kleaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226256992, :text ":column", :id "a1ZFwSgoFG"}
-            }
-           }
-          }
-         }
-         "yr" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1549972433949, :id "y5iHFuP_l3"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text "{}", :id "8Ky0KaPZ-l"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1549972433949, :id "hjhkCB4tpf"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text ":value", :id "qQOaG6l6Rh"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text ":center", :id "qgIuUGcxXO"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1549972433949, :id "uB37QO2SNG"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text ":display", :id "8Fg0JQgoXY"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text "\"Center", :id "dJfU8Y3heu"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553226259302, :id "jTkE6FOFp4"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227877675, :text ":kind", :id "jTkE6FOFp4leaf"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227887624, :text ":center", :id "v2E4PTfde"}
-            }
-           }
-          }
-         }
-         "yv" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "7HK0QlJbWO"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text "{}", :id "xPndLniOAL"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "ElWR_n3y90"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":value", :id "vEO0Czabds"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":row-center", :id "Ls7wYZBlPZ"}
-            }
-           }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "bvxirIHe-l"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":display", :id "nL2kcwvBRM"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text "\"Row Center", :id "HfBfsXJF8o"}
-            }
-           }
-           "v" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "4QTJMvcn6C"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":kind", :id "zR7l59CQe2"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":center", :id "ejkEjz2uX9"}
-            }
-           }
-          }
-         }
-        }
-       }
-      }
-     }
-     "props-hints" {
-      :type :expr, :by "B1y7Rc-Zz", :at 1551634218077, :id "JTr9aHUjwj"
-      :data {
-       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634219405, :text "def", :id "GO1XX495B2"}
-       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634218077, :text "props-hints", :id "8jLaMWXReV"}
-       "r" {
-        :type :expr, :by "B1y7Rc-Zz", :at 1551634218077, :id "H9ZuBNoTXx"
-        :data {
-         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634220459, :text "{}", :id "QrqMEqLnFC"}
-         "j" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634221228, :id "CZVTeIpT0Z"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634226268, :text ":box", :id "zzwWhWPD9"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634226634, :id "Y10ABYnqc"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634227010, :text "[]", :id "tvwC6aDm7i"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193473973, :text "\"param", :id "y5lBTEKQCS"}
-            }
-           }
-          }
-         }
-         "r" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634234597, :id "pF5fOzZ4Q"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634237773, :text ":space", :id "pF5fOzZ4Qleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634238114, :id "M5iTGKTM_1"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634238362, :text "[]", :id "BQ74XXWsnY"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634240125, :text "\"width", :id "agFhQw8cY"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634241338, :text "\"height", :id "3t5gvq2rDE"}
-            }
-           }
-          }
-         }
-         "v" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634242133, :id "92s5XhK2X-"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634247314, :text ":divider", :id "92s5XhK2X-leaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634248224, :id "7vqtO1Y0x9"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634247842, :text "[]", :id "9n6EGZ_GOz"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634249785, :text "\"kind", :id "8wST_qaWo"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634255832, :text "\"color", :id "bE1Rjrvcua"}
-            }
-           }
-          }
-         }
-         "w" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634555611, :id "cMRkcnM5jG"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634555611, :text ":text", :id "BEHEN7FOZO"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634555611, :id "w--89UMTbT"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634555611, :text "[]", :id "ga3cA16sVb"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634555611, :text "\"value", :id "8na-YgWXEp"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555218890726, :text "\"data", :id "6otYh5UrSr"}
-            }
-           }
-          }
-         }
-         "x" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634257255, :id "Tx8OwXmhUq"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634260645, :text ":some", :id "Tx8OwXmhUqleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634261490, :id "UI-Nuxr6OS"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634261719, :text "[]", :id "WyZavGEk7B"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634263044, :text "\"value", :id "BXvhvgIo2F"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634264442, :text "\"kind", :id "FVg6zxocq8"}
-            }
-           }
-          }
-         }
-         "y" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634265267, :id "P-lOqC8Qei"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634269716, :text ":button", :id "P-lOqC8Qeileaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634270426, :id "hwT86AzYiU"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634270952, :text "[]", :id "0IHxy26b-m"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634273192, :text "\"text", :id "veI-Q0u7x_"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193479647, :text "\"param", :id "q9kp5r-Pdn"}
-            }
-           }
-          }
-         }
-         "yT" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634276844, :id "gva0OSnmv"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634283744, :text ":link", :id "gva0OSnmvleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634284097, :id "KN1L6ip-g2"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634284340, :text "[]", :id "R3b98devRl"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634285484, :text "\"text", :id "e9gmOARff"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634286351, :text "\"href", :id "fF4m1f6WQ"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193482805, :text "\"param", :id "jEXKjOpAg"}
-            }
-           }
-          }
-         }
-         "yj" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634290968, :id "Het1Rh2MOu"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634294921, :text ":icon", :id "Het1Rh2MOuleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634296888, :id "WaGINyb0f6"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634296558, :text "[]", :id "t5G-oWmuR"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634298866, :text "\"name", :id "ND4y4OA1PK"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634300452, :text "\"color", :id "pRP0fjbVr2"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193485982, :text "\"param", :id "shQbrWxxO"}
-            }
-           }
-          }
-         }
-         "yr" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634312683, :id "ePBqZALBg"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634317195, :text ":template", :id "ePBqZALBgleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634317385, :id "HMaiATguGZ"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634317576, :text "[]", :id "1V6L3k08-E"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634318617, :text "\"name", :id "hnUKdzVrmP"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634321068, :text "\"data", :id "C7UnKZo5r8"}
-            }
-           }
-          }
-         }
-         "yu" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634562932, :id "I8xDyON1ah"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634563826, :text ":list", :id "I8xDyON1ahleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634564117, :id "Ys3BZvoy6l"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634564439, :text "[]", :id "2PROqlexOz"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634566329, :text "\"value", :id "C7R18of2I"}
-            }
-           }
-          }
-         }
-         "yx" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634327625, :id "6r8mrQXT3"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634331259, :text ":input", :id "6r8mrQXT3leaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634331885, :id "XJ7UNl6Sz0"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634332097, :text "[]", :id "LWXRmYEUi"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634337509, :text "\"value", :id "XIuuE88Wmm"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634340520, :text "\"textarea", :id "jDqAa4yWN"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193491249, :text "\"param", :id "HmMCmShjdP"}
-            }
-           }
-          }
-         }
-         "yy" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634348891, :id "Q81b-VNDoo"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634353518, :text ":slot", :id "Q81b-VNDooleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634354729, :id "XIj0_m8sB"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634354939, :text "[]", :id "SFG_6_mhh4"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634356508, :text "\"dom", :id "PXDE1RtCeK"}
-            }
-           }
-          }
-         }
-         "yyT" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634357323, :id "6ZLhw8H3s5"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552231169917, :text ":inspect", :id "6ZLhw8H3s5leaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634362974, :id "smmTOGIB04"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634362672, :text "[]", :id "VMfSdgdANP"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412412947, :text "\"value", :id "2kVfLdkYGO"}
-            }
-           }
-          }
-         }
-         "yyj" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634365707, :id "dQBvqCYrf"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634370414, :text ":popup", :id "dQBvqCYrfleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634370809, :id "4DfDi0k_xH"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634371360, :text "[]", :id "YNiBBVqvb"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634373253, :text "\"visible", :id "0kTQOat0N"}
-            }
-           }
-          }
-         }
-         "yyr" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634374142, :id "9Sg_y9YxhV"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634380078, :text ":case", :id "9Sg_y9YxhVleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634380393, :id "jGyeR-3023"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634380703, :text "[]", :id "r69ptrOWnD"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634382300, :text "\"value", :id "t5wp5mrtnl"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555217682286, :text "\"options", :id "wVL0qjIbh"}
-            }
-           }
-          }
-         }
-         "yyv" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1551634385746, :id "pb_QvhL_P"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634388157, :text ":element", :id "pb_QvhL_Pleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1551634389051, :id "C2B46mb42G"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634388761, :text "[]", :id "a0jmmNTsBc"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634390105, :text "\"name", :id "NUGcZse_SL"}
-            }
-           }
-          }
-         }
-         "yyx" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1552412404026, :id "EMIgs9PieA"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412406011, :text ":markdown", :id "EMIgs9PieAleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552412406527, :id "R9fM-N4z_"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412406745, :text "[]", :id "C-S5PquHSZ"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412408647, :text "\"text", :id "LiFS8uAFNF"}
-            }
-           }
-          }
-         }
-         "yyy" {
-          :type :expr, :by "B1y7Rc-Zz", :at 1553017640859, :id "KtRfMdog4q"
-          :data {
-           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017642992, :text ":image", :id "KtRfMdog4qleaf"}
-           "j" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1553017643440, :id "2WKicimH0i"
-            :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017643731, :text "[]", :id "PYX6oqSWBI"}
-             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017645742, :text "\"src", :id "SuKK6ZWqMk"}
-             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017646599, :text "\"mode", :id "U_06apPTZR"}
-             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017648478, :text "\"width", :id "clWlHeOZ8H"}
-             "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017650181, :text "\"height", :id "Gcr0Orn-V"}
             }
            }
           }
@@ -12826,6 +11546,1071 @@
     }
     :proc {
      :type :expr, :id "SJ1Uz9LeeAB-", :by nil, :at 1500541010211
+     :data {}
+    }
+   }
+   "composer.comp.operations" {
+    :ns {
+     :type :expr, :by "B1y7Rc-Zz", :at 1555692836458, :id "dt7OhM4TCt"
+     :data {
+      "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692836458, :text "ns", :id "rBSt4MDaMv"}
+      "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692836458, :text "composer.comp.operations", :id "gDzYKhD242"}
+      "r" {
+       :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "wvxPvtUvjo"
+       :data {
+        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":require", :id "lt8SjEh0AF"}
+        "j" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "eq1_3s3-5m"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "UR-_KUIqJB"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "hsl.core", :id "92sp-lKUJ8"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "Z0-6DKMvtB"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "kT8NwCdhCB"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "0XQvyHB7jD"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "hsl", :id "X2rp6QWsbh"}
+           }
+          }
+         }
+        }
+        "r" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "reW9pAgg0q"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "c9mk_mKLXv"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "composer.schema", :id "rg5N9SdQiO"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":as", :id "HvPzC6tgZK"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "schema", :id "IA68sNhvlQ"}
+         }
+        }
+        "v" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "JyV8nDvCmw"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "jUtKfWo1DJD"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "respo-ui.core", :id "0hyxyY80z6s"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":as", :id "aAl0kBfbxeF"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "ui", :id "0OEmOK_clTt"}
+         }
+        }
+        "x" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "UAfWkVtG4B-"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "AfeTmDArC0U"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "respo.core", :id "C73PDKTchaV"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "CJCQ3BIj62w"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "lEiinxReEyH"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "ektGcqivucW"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "defcomp", :id "GOIWoM31rM-"}
+            "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "list->", :id "4Kc3Xnwg8sk"}
+            "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "cursor->", :id "okDuc_9IaNJ"}
+            "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "<>", :id "SbLlBrMkr7F"}
+            "y" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "span", :id "8DwX_Ypphxv"}
+            "yT" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "div", :id "b1VhF8rCd81"}
+            "yj" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "button", :id "pqpeAex8FrV"}
+            "yr" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "a", :id "Hvjxv19ieiS"}
+            "yv" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "pre", :id "At-6VRObVXL"}
+           }
+          }
+         }
+        }
+        "y" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "xLPCI76y1wn"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "BD70peiMhnj"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "respo.comp.space", :id "xO1TS5Z09Hg"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "qwjBKZd5RXJ"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "h-QzGaeSDx-"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "mPZdlNPkO10"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "=<", :id "vocxzGUEz92"}
+           }
+          }
+         }
+        }
+        "yT" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "mG53N9RXQ-G"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "LeuX46WOjg7"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "composer.config", :id "I50qFnmp66E"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":as", :id "u79HqUXC4tJ"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "config", :id "7cFAQvNeuIz"}
+         }
+        }
+        "yj" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "4BNrn9K3jwo"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "C4I4zOV0T83"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "respo.comp.inspect", :id "I-GZZ5cUr1K"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "sOvrjHZ3rTL"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "XI_t1wIkGWf"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "On8CNZF-4tc"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "comp-inspect", :id "XWXlR5uatWU"}
+           }
+          }
+         }
+        }
+        "yr" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "fN4dkTeqSdi"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "WovA3AiaHtN"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "respo.util.list", :id "LyXrlX4M2_A"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "S4vbbV2lo5u"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "uDeLTeKTwtb"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "Zk8aSnvvrES"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "map-val", :id "r3vKVEQK8NF"}
+           }
+          }
+         }
+        }
+        "yv" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "CYiHl_pCOnk"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "J84ccHB4Zni"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "respo-alerts.comp.alerts", :id "nWdvRe3R0qS"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "VeFAa-Pm4zX"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "7DqFBNs-uM1"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "B_Fr24f2QIP"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "comp-prompt", :id "yyHwjGoC97z"}
+            "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "comp-confirm", :id "ooE60yKd1C9"}
+            "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "comp-select", :id "Pi3V026K1vf"}
+           }
+          }
+         }
+        }
+        "yx" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "7jOjy5j7Zqy"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "PIBfZCjrH_m"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "composer.util", :id "ptL_IxF6FXL"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "c4MUlQha8qy"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "h6GU_9vcbbe"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "lXeOHwQf2oy"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "path-with-children", :id "s-0AFxKjWPC"}
+           }
+          }
+         }
+        }
+        "yy" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "A-h82ydW3o_"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "uL60QKKJBc1"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "inflow-popup.comp.popup", :id "6takheaWGOE"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":refer", :id "5FvNTzHQTmB"}
+          "v" {
+           :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "wosGqSc-hp9"
+           :data {
+            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "4naSu9var5i"}
+            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "comp-popup", :id "qTu-KwtiSDt"}
+           }
+          }
+         }
+        }
+        "yyx" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "B0ppbJaiZYv"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "2xIC84HXRsR"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "composer.style", :id "NMxpYx1dQJk"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":as", :id "XzFha_WJlSQ"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "style", :id "NFEcfnrjkZL"}
+         }
+        }
+        "yyy" {
+         :type :expr, :by "B1y7Rc-Zz", :at 1555692915865, :id "oDSW3VsJd9i"
+         :data {
+          "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "[]", :id "ZIo_xS9O8lc"}
+          "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "bisection-key.core", :id "cwOwRK1gMA9"}
+          "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text ":as", :id "9EQ-Ms6xmyp"}
+          "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1555692915865, :text "bisection", :id "fqxkq9ELBhD"}
+         }
+        }
+       }
+      }
+     }
+    }
+    :defs {
+     "comp-operations" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1548610853161, :id "FmbD7ZFwkF"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610854649, :text "defcomp", :id "G5Gr3K0Qmp"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610853161, :text "comp-operations", :id "g5QCj7peMC"}
+       "n" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1548610855494, :id "LLpirstZeM"
+        :data {
+         "5" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693649011, :text "states", :id "-89nlofTE2"}
+         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611150659, :text "template-id", :id "XDIhMQoMp"}
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610866143, :text "focused-path", :id "GcKeVt_Dp"}
+        }
+       }
+       "v" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "qncOfyqD0P"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "div", :id "aV60yOg1Z4"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "5U3JzsLX3Y"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "{}", :id "Vbr19KiFEF"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "DzhA-pX-2a"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text ":style", :id "wlgMEHEelq"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "y1xEqDLo6b"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "merge", :id "USAw8uU9zn"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617983250, :text "ui/row", :id "QPPljxwBza"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "3xZjQbA64R"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "{}", :id "TpsIKAc_y_"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1551549464627, :id "s-t3mJjNC"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551549465699, :text ":padding", :id "Us9QyYYcaf"}
+                   "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551549697663, :text "\"0 8px", :id "5-_clryu3w"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "GVGNBudk6A"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "div", :id "oeGPkXVyGX4"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "8DDv1Cjl7GW"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "{}", :id "oCo_Es4Og_t"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548610890944, :id "0UECM55ZYZF"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610890944, :text "<>", :id "6F4ozY9_vfm"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617987530, :text "\"Operations:", :id "b9B8GR2GdC1"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550408912242, :text "style/field-label", :id "K0dg-Cxp6O"}
+            }
+           }
+          }
+         }
+         "v" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "-nWGhIVBnZ"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "div", :id "61IWLMc4fo"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "5m24ZqfCZb"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "{}", :id "wE23PPAFqF"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548693910265, :id "73DPVN1VsX"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693911001, :text ":style", :id "Q36ZSIHtU4"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550592931725, :id "CsIdxE0BoI"
+                :data {
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550592934582, :text "merge", :id "2BMqFgjlhR"}
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510036397, :text "ui/flex", :id "xeroA9ykN7"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "YgPNY3JJ3E"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617952176, :text "a", :id "RBLOfII1IU"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "_v3v5AZQ8i"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "{}", :id "qwCEd-TyD_"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "Gl4KVjq2PO"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text ":style", :id "4j-gLs-Bph"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593008669, :text "style/link", :id "wyYycb3YI-"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548610894050, :id "dvwkBeGJ1n"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text ":inner-text", :id "-utEcJ5MWv"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610894050, :text "\"Append", :id "2VPQ9sP5T4"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548610941592, :id "qTJHJ1ycm"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610944080, :text ":on-click", :id "qTJHJ1ycmleaf"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548610944394, :id "ZfKGu8choY"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610944677, :text "fn", :id "xUxeQ1iCqk"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548610944968, :id "uzC9fku9wj"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610945133, :text "e", :id "kxdat_b-Wu"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610945680, :text "d!", :id "hrazyGqfqO"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610946306, :text "m!", :id "FiEcHnovti"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548610946800, :id "7HllAyR4Ae"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610947448, :text "d!", :id "7HllAyR4Aeleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548610962990, :text ":template/append-markup", :id "lPV_-WiCj"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548611134279, :id "IZ1isdn8KS"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611135870, :text "{}", :id "eqCXq3x8_"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548611136211, :id "sxXvVCdmnW"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611141335, :text ":template-id", :id "UHv0dDQCS5"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611162394, :text "template-id", :id "y0xYFiMprh"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548611143092, :id "eGHAN_FXpY"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548611144567, :text ":path", :id "eGHAN_FXpYleaf"}
+                         "j" {:type :leaf, :by "root", :at 1548675042762, :text "focused-path", :id "C8aBmKB0AS"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548781907388, :id "4DUx6WFbLp"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781909657, :text "d!", :id "4DUx6WFbLpleaf"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781978406, :text ":router/move-append", :id "Ek9XnARW4R"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781915305, :text "nil", :id "HVMMnB3oy"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "s" {
+            :type :expr, :by "root", :at 1548675907462, :id "cgcmN3uSVt"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617959258, :text "a", :id "knsuDhOX8T"}
+             "j" {
+              :type :expr, :by "root", :at 1548675907462, :id "Tv0kew0i8M"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1548675907462, :text "{}", :id "Cd-oJqygeN"}
+               "j" {
+                :type :expr, :by "root", :at 1548675907462, :id "U_oUL9UFZu"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1548675907462, :text ":style", :id "LPBhXjcUI3"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593011375, :text "style/link", :id "7Aa2F29-d2"}
+                }
+               }
+               "r" {
+                :type :expr, :by "root", :at 1548675907462, :id "kHHE4ywQTJ"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1548675907462, :text ":inner-text", :id "-y7qhdEZO_"}
+                 "j" {:type :leaf, :by "root", :at 1548675914472, :text "\"After", :id "jFbr6HQJ1Z"}
+                }
+               }
+               "v" {
+                :type :expr, :by "root", :at 1548675907462, :id "h3QU1ok7D0"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1548675907462, :text ":on-click", :id "e2I087UCfi"}
+                 "j" {
+                  :type :expr, :by "root", :at 1548675907462, :id "NAgT86A1A_"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1548675907462, :text "fn", :id "LvwxP7ZYKRh"}
+                   "j" {
+                    :type :expr, :by "root", :at 1548675907462, :id "sBwcXv5qoce"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1548675907462, :text "e", :id "l34RShswpVj"}
+                     "j" {:type :leaf, :by "root", :at 1548675907462, :text "d!", :id "gcPRFa79wHK"}
+                     "r" {:type :leaf, :by "root", :at 1548675907462, :text "m!", :id "4XH7G_ElUFU"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "root", :at 1548675907462, :id "eRQqy3eOJvt"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1548675907462, :text "d!", :id "aestIlFvyt3"}
+                     "j" {:type :leaf, :by "root", :at 1548675918607, :text ":template/after-markup", :id "x8R-fsvlMdh"}
+                     "r" {
+                      :type :expr, :by "root", :at 1548675907462, :id "_E3fAQLA_E9"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1548675907462, :text "{}", :id "c3mMH9VR6MO"}
+                       "j" {
+                        :type :expr, :by "root", :at 1548675907462, :id "WWRA1A5wqkW"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1548675907462, :text ":template-id", :id "93xusauJ_5Z"}
+                         "j" {:type :leaf, :by "root", :at 1548675907462, :text "template-id", :id "DI40JSR9DFZ"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1548675907462, :id "50HXZnA9u58"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1548675907462, :text ":path", :id "R159VyITcsD"}
+                         "j" {:type :leaf, :by "root", :at 1548675907462, :text "focused-path", :id "ndMPhQpZL8n"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548781917876, :id "zSjYK8QRrf"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781917876, :text "d!", :id "ep1n27Ty5b"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781975739, :text ":router/move-after", :id "6nd__GVwXp"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781917876, :text "nil", :id "BZieHQeli7"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "sj" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "9nTwOcbckO"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617963206, :text "a", :id "u3oo1oQBpp"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "pndZqS79G7"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "fIVI4pYCHJ"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "LcvYSsTnIA"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":style", :id "_hYbZxT9fq"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593013539, :text "style/link", :id "FmEqWHgF7Z"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "4hPZU0Vbja"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":inner-text", :id "XKKY4jmTZ7"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693809077, :text "\"Prepend", :id "zyuC6zQF93"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "bjtoqyxbes"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":on-click", :id "gdTsS5vx6M"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "wgl7XRTYXG"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "fn", :id "zndB-T642q"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "FFNC3b3eA-"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "e", :id "Srh8Ab50KDg"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "zt_NIk_TMTV"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "m!", :id "zW9q3uVmPpP"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "DrnCGY42gdP"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "RsvI_0n74a9"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693814717, :text ":template/prepend-markup", :id "EQdw576dVF1"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "cAZiMewEhp7"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "TvZudKQB4GT"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "CjBgSMs1zrw"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":template-id", :id "3-V6yrZWKtV"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "template-id", :id "tUlHge3uyPt"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "WUWAodY_L_-"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":path", :id "39yq_mieU8y"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "focused-path", :id "saRtHRPotxA"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548781922371, :id "zPtd_3Ubdt"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781922371, :text "d!", :id "dHy-NT3JWd"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781973563, :text ":router/move-prepend", :id "9_dgjXccuw"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781922371, :text "nil", :id "eh_KsbZogq"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "sr" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "PT_MgAu2pC"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617966585, :text "a", :id "u3oo1oQBpp"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "pndZqS79G7"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "fIVI4pYCHJ"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "LcvYSsTnIA"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":style", :id "_hYbZxT9fq"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593015076, :text "style/link", :id "FmEqWHgF7Z"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "4hPZU0Vbja"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":inner-text", :id "XKKY4jmTZ7"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693880208, :text "\"Before", :id "zyuC6zQF93"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "bjtoqyxbes"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":on-click", :id "gdTsS5vx6M"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "wgl7XRTYXG"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "fn", :id "zndB-T642q"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "FFNC3b3eA-"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "e", :id "Srh8Ab50KDg"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "zt_NIk_TMTV"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "m!", :id "zW9q3uVmPpP"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "DrnCGY42gdP"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "d!", :id "RsvI_0n74a9"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693887397, :text ":template/before-markup", :id "EQdw576dVF1"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "cAZiMewEhp7"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "{}", :id "TvZudKQB4GT"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "CjBgSMs1zrw"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":template-id", :id "3-V6yrZWKtV"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "template-id", :id "tUlHge3uyPt"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548693804656, :id "WUWAodY_L_-"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text ":path", :id "39yq_mieU8y"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693804656, :text "focused-path", :id "saRtHRPotxA"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548781930999, :id "s3qiSai1Cq"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781930999, :text "d!", :id "-TGEXrOL1m"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781954896, :text ":router/move-before", :id "satv4jK9KM"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548781930999, :text "nil", :id "C2Ti7l9uay"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "w" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "hm1dT4mvir"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "cursor->", :id "Dp_c30ZEAw"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":remove", :id "6NrRsRer3c"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "comp-confirm", :id "xROU5GNsJx"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "states", :id "FQF8GxBmtg"}
+             "x" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "N0YSSrgJqy"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "{}", :id "-vmUyb02mL"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "POdDWDJqZd"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":trigger", :id "KzX3bZ4Mpq"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "UlK0VH03aF"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617970677, :text "a", :id "hgj-zGHNrx"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "fKh1CyOADH"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "{}", :id "Db_xOrQAx9"}
+                     "j" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "RFyQiYJiuU"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":style", :id "vnv_Ese_2QE"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549617972424, :text "ui/link", :id "ldn-BvVzpar"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "xNGiUoUibEh"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":inner-text", :id "4gCvaLlCy0V"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "\"Remove", :id "MBgXZ_WxKlK"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+             "y" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "sy2g7vstzXn"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "fn", :id "NuB3IKUjnUf"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "gbOe3C2VHb-"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "e", :id "psgwfz0z3AP"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "d!", :id "B2Gb05ajvmE"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "m!", :id "WY2O0_MBjUb"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "Fqhb053w6Qa"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "d!", :id "gRH3pBU8xVn"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":template/remove-markup", :id "r44qn8X3Q8n"}
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "gRcTQH3k7Cy"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "{}", :id "TeMOMNziZsa"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "HNgqztgA6H6"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":template-id", :id "wxRwJiJS3E5"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "template-id", :id "2jjYZQSK39X"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "PiqtqOy3pf8"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text ":path", :id "nFE_Mb_VxGB"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "focused-path", :id "LThbGL7Anw5"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "OHj58P3GZ4j"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "d!", :id "AeyC87WGQzU"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989437966, :text ":session/focus-to", :id "qILXoGbfbRL"}
+                 "r" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1550989438483, :id "cGytzB0JSN"
+                  :data {
+                   "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989441402, :text "{}", :id "hMB-ODI9b"}
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550989442157, :id "5qmZH1jEUk"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989449261, :text ":path", :id "W2OU2depAb"}
+                     "T" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "hau1krOldv0"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "vec", :id "BCDn60BWD_x"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1548693987933, :id "SYnYBbc_vv1"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "butlast", :id "30ipRz6m-Ja"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548693987933, :text "focused-path", :id "QYUmFgh-9tX"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "x" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "BjjR_wL4NP"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "a", :id "inNLMR1lqa"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "9wV5fwJDWs"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "JpQF28I-VK"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6xWixEzHlL"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":style", :id "GNubpIc-FT"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593017603, :text "style/link", :id "i2YmlsvkGF"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "htClbDTKG4"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":inner-text", :id "CYLLqr8LSV"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510121203, :text "\"Wrap", :id "TMfvn-dsjL"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "4M3_BXHkOt"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":on-click", :id "etVLih8wkJ"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "jv1921JDM6"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "fn", :id "rdcsr2KTEYs"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "Bf4M9vCcHXM"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "e", :id "mJlHCoVt-J1"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "cOWl2Rw8FrA"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "m!", :id "QGGzRuHn_V4"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6bYp5YIPDCw"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "fHoLf48fgZs"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510151163, :text ":template/wrap-markup", :id "HWjGQ4Yda0w"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "vQWhxcFSYBe"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "YbjyxzFV0kQ"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "5azvXWhPNyD"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":template-id", :id "wgiqMD-zeJi"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "template-id", :id "jCHviSk0TYI"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "3o2YKieSy4N"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":path", :id "LKWtcEx9KYB"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "focused-path", :id "upvwOCui-QH"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "7czFvx4mcmd"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "YjB5-K4EvVT"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989455170, :text ":session/focus-to", :id "eUAFvDzcHjt"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1550989455737, :id "xaod74dP6j"
+                      :data {
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989456387, :text "{}", :id "JaXAzeh06j"}
+                       "T" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550989457962, :id "OCu7sbH8oz"
+                        :data {
+                         "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1550989458983, :text ":path", :id "MPI0sar0dF"}
+                         "T" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1550510607508, :id "dIAyEGdjkN"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510608178, :text "conj", :id "HoulIeTfktf"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510610181, :text "focused-path", :id "zn7-3njl4T"}
+                           "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510614985, :text "bisection/mid-id", :id "nMBjSAZJ35"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "y" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "fDyBEWa_N"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "a", :id "inNLMR1lqa"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "9wV5fwJDWs"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "JpQF28I-VK"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6xWixEzHlL"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":style", :id "GNubpIc-FT"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593019296, :text "style/link", :id "i2YmlsvkGF"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "htClbDTKG4"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":inner-text", :id "CYLLqr8LSV"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510138597, :text "\"Spread", :id "TMfvn-dsjL"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "4M3_BXHkOt"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":on-click", :id "etVLih8wkJ"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "jv1921JDM6"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "fn", :id "rdcsr2KTEYs"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "Bf4M9vCcHXM"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "e", :id "mJlHCoVt-J1"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "cOWl2Rw8FrA"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "m!", :id "QGGzRuHn_V4"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "6bYp5YIPDCw"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "fHoLf48fgZs"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510147323, :text ":template/spread-markup", :id "HWjGQ4Yda0w"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "vQWhxcFSYBe"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "{}", :id "YbjyxzFV0kQ"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "5azvXWhPNyD"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":template-id", :id "wgiqMD-zeJi"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "template-id", :id "jCHviSk0TYI"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "3o2YKieSy4N"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":path", :id "LKWtcEx9KYB"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "focused-path", :id "upvwOCui-QH"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550510014433, :id "7czFvx4mcmd"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "d!", :id "YjB5-K4EvVT"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text ":router/move-before", :id "eUAFvDzcHjt"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550510014433, :text "nil", :id "HoulIeTfktf"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "yT" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "96gDLRxJ2K"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "a", :id "gnC04QdTZx"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "kjyigxJoSb"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "{}", :id "jtaPgJmhOF"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "5W9n9d085k"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":style", :id "DFS3ounO1V"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "style/link", :id "lieRRk5kyF"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "rsos_Sakct"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":inner-text", :id "ojXelJ2bFC"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593113046, :text "\"Copy", :id "400DNoPxvH"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "facw9jtfDe"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":on-click", :id "lqmvGeNBZk"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "RDEPl0C9ng"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "fn", :id "rcGucns-qH"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "FzyutH1ovAQ"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "e", :id "eJhahnRdFhy"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "d!", :id "W42a0C70IJi"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "m!", :id "EAwp8AP9Vv5"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "9Hxn948Da_g"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "d!", :id "c_24nUh9NbE"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550597031437, :text ":session/copy-markup", :id "ZT3C4eScok9"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "b-CUtJjI3sJ"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "{}", :id "ddgt2G7eOYT"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "-N-YozvOpkX"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":template-id", :id "l_e37mL-6B7"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "template-id", :id "kGH1zQFWGIU"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550593108457, :id "rwRXZnHhYbr"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text ":path", :id "a4TBaDUjG7F"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593108457, :text "focused-path", :id "vOa7GVnAZXq"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+           "yj" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "mZwkWISGcr"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "a", :id "JabJfq5HNc"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "R-5jkQXg-B"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "{}", :id "NbP7LHJTgH"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "HYqVMqvUvB"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":style", :id "aZQc5H9VfK"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "style/link", :id "YPnO88XPBK"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "BiVIXnDxXZ"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":inner-text", :id "lgp7-q3Wen"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593150023, :text "\"Paste", :id "RqLFwcmXkA"}
+                }
+               }
+               "v" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "05sT4bDpo5"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":on-click", :id "14CafIQBJI"}
+                 "j" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "Wvl-N0uHZE"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "fn", :id "rZY_OWHSTiY"}
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "xM6SBeT39yj"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "e", :id "0Fn6-EC-sZV"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "d!", :id "4IjrV1VjUP5"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "m!", :id "_LNZMsLWrMg"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "SPMgBlNFUhL"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "d!", :id "syhm9U0EL1W"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550597033329, :text ":session/paste-markup", :id "sA8B0mxQrgH"}
+                     "r" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "veMq3oEL65t"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "{}", :id "Y72lHxnQ78L"}
+                       "j" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "L7_DzoFfUCU"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":template-id", :id "YTXZ2-T1VX3"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "template-id", :id "mlYG4NERBUQ"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1550593110371, :id "cGgNtkbzbwE"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text ":path", :id "XvGAgfrK17a"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1550593110371, :text "focused-path", :id "ftXRtyjfmNf"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+    :proc {
+     :type :expr, :by "B1y7Rc-Zz", :at 1555692836458, :id "25T4BzgFGL"
      :data {}
     }
    }
@@ -32135,6 +31920,471 @@
           :data {
            "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548568025538, :text ":name", :id "SwivgB-64Wleaf"}
            "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548568026855, :text "nil", :id "aYtZwJeJM4"}
+          }
+         }
+        }
+       }
+      }
+     }
+     "node-layouts" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1548747538542, :id "CxdQWjlEcC"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747539532, :text "def", :id "GZcS7qeSuN"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747538542, :text "node-layouts", :id "FuGKfDyKA0"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1548747538542, :id "BlGjArD8AP"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747540545, :text "[]", :id "jWx9VqGl8p"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548747541005, :id "bRdqHIzUDQ"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747541626, :text "{}", :id "T_8DPOuYhd"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548747541958, :id "mxjARIh-6C"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747543132, :text ":value", :id "X4tqIZAeMh"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747556431, :text ":row", :id "ANJpviaIOJ"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548747557380, :id "hlUIRXviOW"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747558620, :text ":display", :id "hlUIRXviOWleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747563464, :text "\"Row", :id "a1F4u2GhGu"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226225352, :id "B6WytXQzw"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226227210, :text ":kind", :id "B6WytXQzwleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226229943, :text ":row", :id "0EPMaCSujJ"}
+            }
+           }
+          }
+         }
+         "l" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1549972422842, :id "DFykNRAG7B"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text "{}", :id "R3OzoQDn2o"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1549972422842, :id "b1FbEMyqfP"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text ":value", :id "dYECnsM0uP"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text ":row-middle", :id "4W8SF-uTJe"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1549972422842, :id "PIsDY6goo-"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text ":display", :id "ro4D0zUax7"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972422842, :text "\"Row Middle", :id "OAkLOXxePC"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226232161, :id "FHg252v8NF"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226233851, :text ":kind", :id "FHg252v8NFleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226235169, :text ":row", :id "VxIBii3pOY"}
+            }
+           }
+          }
+         }
+         "m" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1549972426812, :id "GbyRQ5G2To"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text "{}", :id "lznF7hSpCT"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1549972426812, :id "Fl_P_uISYo"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text ":value", :id "kJTTEZ99Zm"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text ":row-parted", :id "uWcfEuMUlA"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1549972426812, :id "TvCrDusPTX"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text ":display", :id "9-PQkfqYXd"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972426812, :text "\"Row Parted", :id "FyF25oF-sH"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226236592, :id "QDQRIqOi-"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226238410, :text ":kind", :id "QDQRIqOi-leaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226240341, :text ":row", :id "QPRYEw0LI"}
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548747564797, :id "howRYt-M3"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747565712, :text "{}", :id "howRYt-M3leaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548747566048, :id "ZyURcgh5X6"
+            :data {
+             "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747571030, :text ":value", :id "5vUB-bzCK"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747568254, :text ":column", :id "Ww4-zzE6vd"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548747571654, :id "6vn04-fQO"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747572883, :text ":display", :id "6vn04-fQOleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747574548, :text "\"Column", :id "FNZH_517kh"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226247185, :id "6l-7YanwwQ"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226248356, :text ":kind", :id "6l-7YanwwQleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226250855, :text ":column", :id "eJq32ygUK5"}
+            }
+           }
+          }
+         }
+         "yj" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1548747575584, :id "yph6t9HONE"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747576273, :text "{}", :id "jfXC6P-ajleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548747576670, :id "2XFleAIN2"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747582424, :text ":value", :id "iSw2dGddW7"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747627381, :text ":column-parted", :id "MwkYWYViE"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1548747585297, :id "h8laFjdzNW"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747587663, :text ":display", :id "h8laFjdzNWleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1548747631766, :text "\"Column Parted", :id "GxytUe71w8"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226253169, :id "NbthBz2F5K"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226254293, :text ":kind", :id "NbthBz2F5Kleaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553226256992, :text ":column", :id "a1ZFwSgoFG"}
+            }
+           }
+          }
+         }
+         "yr" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1549972433949, :id "y5iHFuP_l3"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text "{}", :id "8Ky0KaPZ-l"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1549972433949, :id "hjhkCB4tpf"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text ":value", :id "qQOaG6l6Rh"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text ":center", :id "qgIuUGcxXO"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1549972433949, :id "uB37QO2SNG"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text ":display", :id "8Fg0JQgoXY"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1549972433949, :text "\"Center", :id "dJfU8Y3heu"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553226259302, :id "jTkE6FOFp4"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227877675, :text ":kind", :id "jTkE6FOFp4leaf"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227887624, :text ":center", :id "v2E4PTfde"}
+            }
+           }
+          }
+         }
+         "yv" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "7HK0QlJbWO"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text "{}", :id "xPndLniOAL"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "ElWR_n3y90"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":value", :id "vEO0Czabds"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":row-center", :id "Ls7wYZBlPZ"}
+            }
+           }
+           "r" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "bvxirIHe-l"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":display", :id "nL2kcwvBRM"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text "\"Row Center", :id "HfBfsXJF8o"}
+            }
+           }
+           "v" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553227897735, :id "4QTJMvcn6C"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":kind", :id "zR7l59CQe2"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553227897735, :text ":center", :id "ejkEjz2uX9"}
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "props-hints" {
+      :type :expr, :by "B1y7Rc-Zz", :at 1551634218077, :id "JTr9aHUjwj"
+      :data {
+       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634219405, :text "def", :id "GO1XX495B2"}
+       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634218077, :text "props-hints", :id "8jLaMWXReV"}
+       "r" {
+        :type :expr, :by "B1y7Rc-Zz", :at 1551634218077, :id "H9ZuBNoTXx"
+        :data {
+         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634220459, :text "{}", :id "QrqMEqLnFC"}
+         "j" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634221228, :id "CZVTeIpT0Z"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634226268, :text ":box", :id "zzwWhWPD9"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634226634, :id "Y10ABYnqc"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634227010, :text "[]", :id "tvwC6aDm7i"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193473973, :text "\"param", :id "y5lBTEKQCS"}
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634234597, :id "pF5fOzZ4Q"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634237773, :text ":space", :id "pF5fOzZ4Qleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634238114, :id "M5iTGKTM_1"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634238362, :text "[]", :id "BQ74XXWsnY"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634240125, :text "\"width", :id "agFhQw8cY"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634241338, :text "\"height", :id "3t5gvq2rDE"}
+            }
+           }
+          }
+         }
+         "v" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634242133, :id "92s5XhK2X-"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634247314, :text ":divider", :id "92s5XhK2X-leaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634248224, :id "7vqtO1Y0x9"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634247842, :text "[]", :id "9n6EGZ_GOz"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634249785, :text "\"kind", :id "8wST_qaWo"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634255832, :text "\"color", :id "bE1Rjrvcua"}
+            }
+           }
+          }
+         }
+         "w" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634555611, :id "cMRkcnM5jG"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634555611, :text ":text", :id "BEHEN7FOZO"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634555611, :id "w--89UMTbT"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634555611, :text "[]", :id "ga3cA16sVb"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634555611, :text "\"value", :id "8na-YgWXEp"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555218890726, :text "\"data", :id "6otYh5UrSr"}
+            }
+           }
+          }
+         }
+         "x" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634257255, :id "Tx8OwXmhUq"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634260645, :text ":some", :id "Tx8OwXmhUqleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634261490, :id "UI-Nuxr6OS"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634261719, :text "[]", :id "WyZavGEk7B"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634263044, :text "\"value", :id "BXvhvgIo2F"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634264442, :text "\"kind", :id "FVg6zxocq8"}
+            }
+           }
+          }
+         }
+         "y" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634265267, :id "P-lOqC8Qei"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634269716, :text ":button", :id "P-lOqC8Qeileaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634270426, :id "hwT86AzYiU"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634270952, :text "[]", :id "0IHxy26b-m"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634273192, :text "\"text", :id "veI-Q0u7x_"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193479647, :text "\"param", :id "q9kp5r-Pdn"}
+            }
+           }
+          }
+         }
+         "yT" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634276844, :id "gva0OSnmv"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634283744, :text ":link", :id "gva0OSnmvleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634284097, :id "KN1L6ip-g2"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634284340, :text "[]", :id "R3b98devRl"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634285484, :text "\"text", :id "e9gmOARff"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634286351, :text "\"href", :id "fF4m1f6WQ"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193482805, :text "\"param", :id "jEXKjOpAg"}
+            }
+           }
+          }
+         }
+         "yj" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634290968, :id "Het1Rh2MOu"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634294921, :text ":icon", :id "Het1Rh2MOuleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634296888, :id "WaGINyb0f6"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634296558, :text "[]", :id "t5G-oWmuR"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634298866, :text "\"name", :id "ND4y4OA1PK"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634300452, :text "\"color", :id "pRP0fjbVr2"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193485982, :text "\"param", :id "shQbrWxxO"}
+            }
+           }
+          }
+         }
+         "yr" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634312683, :id "ePBqZALBg"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634317195, :text ":template", :id "ePBqZALBgleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634317385, :id "HMaiATguGZ"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634317576, :text "[]", :id "1V6L3k08-E"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634318617, :text "\"name", :id "hnUKdzVrmP"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634321068, :text "\"data", :id "C7UnKZo5r8"}
+            }
+           }
+          }
+         }
+         "yu" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634562932, :id "I8xDyON1ah"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634563826, :text ":list", :id "I8xDyON1ahleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634564117, :id "Ys3BZvoy6l"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634564439, :text "[]", :id "2PROqlexOz"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634566329, :text "\"value", :id "C7R18of2I"}
+            }
+           }
+          }
+         }
+         "yx" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634327625, :id "6r8mrQXT3"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634331259, :text ":input", :id "6r8mrQXT3leaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634331885, :id "XJ7UNl6Sz0"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634332097, :text "[]", :id "LWXRmYEUi"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634337509, :text "\"value", :id "XIuuE88Wmm"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634340520, :text "\"textarea", :id "jDqAa4yWN"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552193491249, :text "\"param", :id "HmMCmShjdP"}
+            }
+           }
+          }
+         }
+         "yy" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634348891, :id "Q81b-VNDoo"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634353518, :text ":slot", :id "Q81b-VNDooleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634354729, :id "XIj0_m8sB"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634354939, :text "[]", :id "SFG_6_mhh4"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634356508, :text "\"dom", :id "PXDE1RtCeK"}
+            }
+           }
+          }
+         }
+         "yyT" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634357323, :id "6ZLhw8H3s5"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552231169917, :text ":inspect", :id "6ZLhw8H3s5leaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634362974, :id "smmTOGIB04"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634362672, :text "[]", :id "VMfSdgdANP"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412412947, :text "\"value", :id "2kVfLdkYGO"}
+            }
+           }
+          }
+         }
+         "yyj" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634365707, :id "dQBvqCYrf"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634370414, :text ":popup", :id "dQBvqCYrfleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634370809, :id "4DfDi0k_xH"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634371360, :text "[]", :id "YNiBBVqvb"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634373253, :text "\"visible", :id "0kTQOat0N"}
+            }
+           }
+          }
+         }
+         "yyr" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634374142, :id "9Sg_y9YxhV"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634380078, :text ":case", :id "9Sg_y9YxhVleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634380393, :id "jGyeR-3023"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634380703, :text "[]", :id "r69ptrOWnD"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634382300, :text "\"value", :id "t5wp5mrtnl"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1555217682286, :text "\"options", :id "wVL0qjIbh"}
+            }
+           }
+          }
+         }
+         "yyv" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1551634385746, :id "pb_QvhL_P"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634388157, :text ":element", :id "pb_QvhL_Pleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1551634389051, :id "C2B46mb42G"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634388761, :text "[]", :id "a0jmmNTsBc"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551634390105, :text "\"name", :id "NUGcZse_SL"}
+            }
+           }
+          }
+         }
+         "yyx" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1552412404026, :id "EMIgs9PieA"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412406011, :text ":markdown", :id "EMIgs9PieAleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1552412406527, :id "R9fM-N4z_"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412406745, :text "[]", :id "C-S5PquHSZ"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552412408647, :text "\"text", :id "LiFS8uAFNF"}
+            }
+           }
+          }
+         }
+         "yyy" {
+          :type :expr, :by "B1y7Rc-Zz", :at 1553017640859, :id "KtRfMdog4q"
+          :data {
+           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017642992, :text ":image", :id "KtRfMdog4qleaf"}
+           "j" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1553017643440, :id "2WKicimH0i"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017643731, :text "[]", :id "PYX6oqSWBI"}
+             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017645742, :text "\"src", :id "SuKK6ZWqMk"}
+             "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017646599, :text "\"mode", :id "U_06apPTZR"}
+             "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017648478, :text "\"width", :id "clWlHeOZ8H"}
+             "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1553017650181, :text "\"height", :id "Gcr0Orn-V"}
+            }
+           }
           }
          }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@respo/composer-app",
-  "version": "0.1.6-a1",
+  "version": "0.1.6-a4",
   "description": "Composer app creator for Respo",
   "main": "index.js",
   "bin": {
@@ -16,6 +16,7 @@
     "serve": "http-server dist -s",
     "ln": "cd target && rm -f entry && ln -s ../entry",
     "pkg": "rm -rf dist && shadow-cljs release server",
+    "prepare": "yarn pkg",
     "prod": "yarn install --production"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "copy-text-to-clipboard": "^2.1.0",
     "feather-icons": "^4.21.0",
     "http-server": "^0.11.1",
-    "shadow-cljs": "^2.8.31",
+    "shadow-cljs": "^2.8.32",
     "source-map-support": "^0.5.12"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,7 +6,7 @@
                 [mvc-works/fuzzy-filter "0.0.6"]
                 [cumulo/recollect       "0.5.0"]
                 [cumulo/reel            "0.1.1"]
-                [cumulo/util            "0.1.7"]
+                [cumulo/util            "0.1.8-a1"]
                 [respo                  "0.10.11"]
                 [respo/ui               "0.3.11"]
                 [respo/alerts           "0.3.11"]

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -8,7 +8,7 @@
                 [cumulo/reel            "0.1.1"]
                 [cumulo/util            "0.1.7"]
                 [respo                  "0.10.11"]
-                [respo/ui               "0.3.10"]
+                [respo/ui               "0.3.11"]
                 [respo/alerts           "0.3.11"]
                 [respo/message          "0.3.4"]
                 [respo/feather          "0.1.1"]

--- a/src/composer/comp/bg_picker.cljs
+++ b/src/composer/comp/bg_picker.cljs
@@ -79,7 +79,7 @@
        (cursor-> :panel comp-color-panel states colors bg-color set-color! on-toggle))))))
 
 (defcomp
- comp-font-picker
+ comp-font-color-picker
  (states template-id path markup colors)
  (let [init-color (or (get-in markup [:style "color"]) (hsl 0 0 100))
        set-color! (fn [color d!]

--- a/src/composer/comp/editor.cljs
+++ b/src/composer/comp/editor.cljs
@@ -18,22 +18,16 @@
             [composer.style :as style]
             [bisection-key.core :as bisection]
             [favored-edn.core :refer [write-edn]]
-            [composer.util :refer [filter-path-set]])
+            [composer.util :refer [filter-path-set]]
+            [composer.comp.operations :refer [comp-operations]])
   (:require-macros [clojure.core.strint :refer [<<]]))
-
-(def node-layouts
-  [{:value :row, :display "Row", :kind :row}
-   {:value :row-middle, :display "Row Middle", :kind :row}
-   {:value :row-parted, :display "Row Parted", :kind :row}
-   {:value :column, :display "Column", :kind :column}
-   {:value :column-parted, :display "Column Parted", :kind :column}
-   {:value :center, :display "Center", :kind :center}
-   {:value :row-center, :display "Row Center", :kind :center}])
 
 (defcomp
  comp-layout-name
  (layout-name)
- (let [layout (->> node-layouts (filter (fn [item] (= layout-name (:value item)))) first)]
+ (let [layout (->> schema/node-layouts
+                   (filter (fn [item] (= layout-name (:value item))))
+                   first)]
    (if (some? layout)
      (<> (:display layout) {:padding "2px 8px", :background-color (hsl 0 0 94)})
      (<> "Nothing" {:color (hsl 0 0 80), :font-family ui/font-fancy}))))
@@ -60,7 +54,7 @@
         (let [render-list (fn [kind]
                             (list->
                              {:style ui/column}
-                             (->> node-layouts
+                             (->> schema/node-layouts
                                   (filter (fn [item] (= kind (:kind item))))
                                   (map
                                    (fn [item]
@@ -156,89 +150,6 @@
        (d! :template/use-mock {:template-id (:id template), :mock-id result}))))))
 
 (defcomp
- comp-operations
- (states template-id focused-path)
- (div
-  {:style (merge ui/row {:padding "0 8px"})}
-  (div {} (<> "Operations:" style/field-label))
-  (div
-   {:style (merge ui/flex)}
-   (a
-    {:style style/link,
-     :inner-text "Append",
-     :on-click (fn [e d! m!]
-       (d! :template/append-markup {:template-id template-id, :path focused-path})
-       (d! :router/move-append nil))})
-   (a
-    {:style style/link,
-     :inner-text "After",
-     :on-click (fn [e d! m!]
-       (d! :template/after-markup {:template-id template-id, :path focused-path})
-       (d! :router/move-after nil))})
-   (a
-    {:style style/link,
-     :inner-text "Prepend",
-     :on-click (fn [e d! m!]
-       (d! :template/prepend-markup {:template-id template-id, :path focused-path})
-       (d! :router/move-prepend nil))})
-   (a
-    {:style style/link,
-     :inner-text "Before",
-     :on-click (fn [e d! m!]
-       (d! :template/before-markup {:template-id template-id, :path focused-path})
-       (d! :router/move-before nil))})
-   (cursor->
-    :remove
-    comp-confirm
-    states
-    {:trigger (a {:style ui/link, :inner-text "Remove"})}
-    (fn [e d! m!]
-      (d! :template/remove-markup {:template-id template-id, :path focused-path})
-      (d! :session/focus-to {:path (vec (butlast focused-path))})))
-   (a
-    {:style style/link,
-     :inner-text "Wrap",
-     :on-click (fn [e d! m!]
-       (d! :template/wrap-markup {:template-id template-id, :path focused-path})
-       (d! :session/focus-to {:path (conj focused-path bisection/mid-id)}))})
-   (a
-    {:style style/link,
-     :inner-text "Spread",
-     :on-click (fn [e d! m!]
-       (d! :template/spread-markup {:template-id template-id, :path focused-path})
-       (d! :router/move-before nil))})
-   (a
-    {:style style/link,
-     :inner-text "Copy",
-     :on-click (fn [e d! m!]
-       (d! :session/copy-markup {:template-id template-id, :path focused-path}))})
-   (a
-    {:style style/link,
-     :inner-text "Paste",
-     :on-click (fn [e d! m!]
-       (d! :session/paste-markup {:template-id template-id, :path focused-path}))}))))
-
-(def props-hints
-  {:box ["param"],
-   :space ["width" "height"],
-   :divider ["kind" "color"],
-   :text ["value" "data"],
-   :some ["value" "kind"],
-   :button ["text" "param"],
-   :link ["text" "href" "param"],
-   :icon ["name" "color" "param"],
-   :template ["name" "data"],
-   :list ["value"],
-   :input ["value" "textarea" "param"],
-   :slot ["dom"],
-   :inspect ["value"],
-   :popup ["visible"],
-   :case ["value" "options"],
-   :element ["name"],
-   :markdown ["text"],
-   :image ["src" "mode" "width" "height"]})
-
-(defcomp
  comp-props-hint
  (type)
  (div
@@ -247,7 +158,7 @@
   (=< 8 nil)
   (list->
    {}
-   (->> (get props-hints type)
+   (->> (get schema/props-hints type)
         (map
          (fn [name]
            [name
@@ -292,72 +203,76 @@
         mock-id (:mock-pointer template)
         mock-data (if (nil? mock-id) nil (get-in template [:mocks mock-id :data]))]
     (div
-     {:style (merge ui/flex {:overflow :auto, :padding 8})}
-     (cursor-> :type comp-type-picker states template-id focused-path child)
-     (cursor-> :layout comp-layout-picker states template-id focused-path child)
-     (cursor->
-      :font-color
-      comp-font-picker
-      states
-      template-id
-      focused-path
-      child
-      (:colors settings))
-     (cursor->
-      :background
-      comp-bg-picker
-      states
-      template-id
-      focused-path
-      child
-      (:colors settings))
-     (when config/dev? (comp-inspect "Node" child {:bottom 0}))
-     (cursor-> :presets comp-presets states (:presets child) template-id focused-path)
-     (=< nil 8)
-     (cursor-> :mocks comp-mock-picker states template)
-     (pre {:inner-text (write-edn mock-data), :style style-mock-data})
-     (comp-props-hint (:type child))
-     (cursor->
-      :props
-      comp-dict-editor
-      states
-      "Props:"
-      (:props child)
-      (get props-hints (:type child))
-      (fn [change d! m!]
-        (d!
-         :template/node-props
-         (merge {:template-id template-id, :path focused-path} change))))
-     (cursor->
-      :event
-      comp-dict-editor
-      states
-      "Event:"
-      (:event child)
-      nil
-      (fn [change d! m!]
-        (d!
-         :template/node-event
-         (merge {:template-id template-id, :path focused-path} change))))
-     (cursor->
-      :attrs
-      comp-dict-editor
-      states
-      "Attrs:"
-      (:attrs child)
-      nil
-      (fn [change d! m!]
-        (d!
-         :template/node-attrs
-         (merge {:template-id template-id, :path focused-path} change))))
-     (cursor->
-      :style
-      comp-dict-editor
-      states
-      "Style:"
-      (:style child)
-      nil
-      (fn [change d! m!]
-        (d!
-         :template/node-style
-         (merge {:template-id template-id, :path focused-path} change))))))))
+     {:style (merge ui/flex ui/row {:overflow :auto, :padding 8})}
+     (div
+      {:style ui/expand}
+      (cursor-> :type comp-type-picker states template-id focused-path child)
+      (cursor-> :layout comp-layout-picker states template-id focused-path child)
+      (when config/dev? (comp-inspect "Node" child {:bottom 0}))
+      (cursor-> :presets comp-presets states (:presets child) template-id focused-path)
+      (cursor->
+       :props
+       comp-dict-editor
+       states
+       "Props:"
+       (:props child)
+       (get schema/props-hints (:type child))
+       (fn [change d! m!]
+         (d!
+          :template/node-props
+          (merge {:template-id template-id, :path focused-path} change))))
+      (cursor->
+       :event
+       comp-dict-editor
+       states
+       "Event:"
+       (:event child)
+       nil
+       (fn [change d! m!]
+         (d!
+          :template/node-event
+          (merge {:template-id template-id, :path focused-path} change))))
+      (cursor->
+       :attrs
+       comp-dict-editor
+       states
+       "Attrs:"
+       (:attrs child)
+       nil
+       (fn [change d! m!]
+         (d!
+          :template/node-attrs
+          (merge {:template-id template-id, :path focused-path} change))))
+      (cursor->
+       :style
+       comp-dict-editor
+       states
+       "Style:"
+       (:style child)
+       nil
+       (fn [change d! m!]
+         (d!
+          :template/node-style
+          (merge {:template-id template-id, :path focused-path} change)))))
+     (div
+      {:style ui/expand}
+      (cursor-> :mocks comp-mock-picker states template)
+      (pre {:inner-text (write-edn mock-data), :style style-mock-data})
+      (=< nil 8)
+      (comp-props-hint (:type child))
+      (cursor->
+       :font-color
+       comp-font-picker
+       states
+       template-id
+       focused-path
+       child
+       (:colors settings))
+      (cursor->
+       :background
+       comp-bg-picker
+       states
+       template-id
+       focused-path
+       child
+       (:colors settings)))))))

--- a/src/composer/comp/operations.cljs
+++ b/src/composer/comp/operations.cljs
@@ -1,0 +1,78 @@
+
+(ns composer.comp.operations
+  (:require [hsl.core :refer [hsl]]
+            [composer.schema :as schema]
+            [respo-ui.core :as ui]
+            [respo.core :refer [defcomp list-> cursor-> <> span div button a pre]]
+            [respo.comp.space :refer [=<]]
+            [composer.config :as config]
+            [respo.comp.inspect :refer [comp-inspect]]
+            [respo.util.list :refer [map-val]]
+            [respo-alerts.comp.alerts :refer [comp-prompt comp-confirm comp-select]]
+            [composer.util :refer [path-with-children]]
+            [inflow-popup.comp.popup :refer [comp-popup]]
+            [composer.style :as style]
+            [bisection-key.core :as bisection]))
+
+(defcomp
+ comp-operations
+ (states template-id focused-path)
+ (div
+  {:style (merge ui/row {:padding "0 8px"})}
+  (div {} (<> "Operations:" style/field-label))
+  (div
+   {:style (merge ui/flex)}
+   (a
+    {:style style/link,
+     :inner-text "Append",
+     :on-click (fn [e d! m!]
+       (d! :template/append-markup {:template-id template-id, :path focused-path})
+       (d! :router/move-append nil))})
+   (a
+    {:style style/link,
+     :inner-text "After",
+     :on-click (fn [e d! m!]
+       (d! :template/after-markup {:template-id template-id, :path focused-path})
+       (d! :router/move-after nil))})
+   (a
+    {:style style/link,
+     :inner-text "Prepend",
+     :on-click (fn [e d! m!]
+       (d! :template/prepend-markup {:template-id template-id, :path focused-path})
+       (d! :router/move-prepend nil))})
+   (a
+    {:style style/link,
+     :inner-text "Before",
+     :on-click (fn [e d! m!]
+       (d! :template/before-markup {:template-id template-id, :path focused-path})
+       (d! :router/move-before nil))})
+   (cursor->
+    :remove
+    comp-confirm
+    states
+    {:trigger (a {:style ui/link, :inner-text "Remove"})}
+    (fn [e d! m!]
+      (d! :template/remove-markup {:template-id template-id, :path focused-path})
+      (d! :session/focus-to {:path (vec (butlast focused-path))})))
+   (a
+    {:style style/link,
+     :inner-text "Wrap",
+     :on-click (fn [e d! m!]
+       (d! :template/wrap-markup {:template-id template-id, :path focused-path})
+       (d! :session/focus-to {:path (conj focused-path bisection/mid-id)}))})
+   (a
+    {:style style/link,
+     :inner-text "Spread",
+     :on-click (fn [e d! m!]
+       (d! :template/spread-markup {:template-id template-id, :path focused-path})
+       (d! :router/move-before nil))})
+   (a
+    {:style style/link,
+     :inner-text "Copy",
+     :on-click (fn [e d! m!]
+       (d! :session/copy-markup {:template-id template-id, :path focused-path}))})
+   (a
+    {:style style/link,
+     :inner-text "Paste",
+     :on-click (fn [e d! m!]
+       (d! :session/paste-markup {:template-id template-id, :path focused-path}))}))))

--- a/src/composer/comp/overflow.cljs
+++ b/src/composer/comp/overflow.cljs
@@ -42,11 +42,13 @@
           (map
            (fn [[k template]]
              [k
-              (let [style-container {:background-color (hsl 0 0 100),
-                                     :border "1px solid #ddd",
-                                     :min-width (or (:width template) 240),
-                                     :min-height (or (:height template) 60),
-                                     :position :relative}]
+              (let [style-container (merge
+                                     ui/column
+                                     {:background-color (hsl 0 0 100),
+                                      :border "1px solid #ddd",
+                                      :min-width (or (:width template) 240),
+                                      :min-height (or (:height template) 60),
+                                      :position :relative})]
                 (div
                  {:style (merge ui/row {:margin "16px 0px"})}
                  (div

--- a/src/composer/comp/presets.cljs
+++ b/src/composer/comp/presets.cljs
@@ -11,9 +11,7 @@
             [composer.style :as style]))
 
 (def builtin-presets
-  {"Fonts" [:font-code :font-fancy :font-normal],
-   "Layouts" [:expand :fullscreen :base-padding],
-   "Features" [:scroll :global]})
+  {"Layouts" [:expand :fullscreen :base-padding], "Features" [:scroll :global]})
 
 (defcomp
  comp-preset

--- a/src/composer/comp/preview.cljs
+++ b/src/composer/comp/preview.cljs
@@ -53,11 +53,13 @@
         (if (some? markup)
           (div
            {:class-name (if shadows? "dev-shadows" ""),
-            :style {:background-color (hsl 0 0 100 1),
-                    :width (or (:width template) "100%"),
-                    :height (or (:height template) "100%"),
-                    :margin :auto,
-                    :position :relative}}
+            :style (merge
+                    ui/column
+                    {:background-color (hsl 0 0 100 1),
+                     :width (or (:width template) "100%"),
+                     :height (or (:height template) "100%"),
+                     :margin :auto,
+                     :position :relative})}
            (render-markup markup {:data mock-data, :templates tmpls, :level 0} on-operation))
           (span
            {:style {:color (hsl 0 0 60),

--- a/src/composer/core.cljs
+++ b/src/composer/core.cljs
@@ -109,9 +109,6 @@
    (case preset
      :flex ui/flex
      :expand (merge ui/flex {"scroll" :auto})
-     :font-code {"font-family" ui/font-code}
-     :font-fancy {"font-family" ui/font-fancy}
-     :font-normal {"font-family" ui/font-normal}
      :fullscreen ui/fullscreen
      :scroll {"overflow" :auto}
      :global ui/global

--- a/src/composer/schema.cljs
+++ b/src/composer/schema.cljs
@@ -39,3 +39,32 @@
    :templates (do template {}),
    :saved-templates {},
    :settings {:colors {}}})
+
+(def node-layouts
+  [{:value :row, :display "Row", :kind :row}
+   {:value :row-middle, :display "Row Middle", :kind :row}
+   {:value :row-parted, :display "Row Parted", :kind :row}
+   {:value :column, :display "Column", :kind :column}
+   {:value :column-parted, :display "Column Parted", :kind :column}
+   {:value :center, :display "Center", :kind :center}
+   {:value :row-center, :display "Row Center", :kind :center}])
+
+(def props-hints
+  {:box ["param"],
+   :space ["width" "height"],
+   :divider ["kind" "color"],
+   :text ["value" "data"],
+   :some ["value" "kind"],
+   :button ["text" "param"],
+   :link ["text" "href" "param"],
+   :icon ["name" "color" "param"],
+   :template ["name" "data"],
+   :list ["value"],
+   :input ["value" "textarea" "param"],
+   :slot ["dom"],
+   :inspect ["value"],
+   :popup ["visible"],
+   :case ["value" "options"],
+   :element ["name"],
+   :markdown ["text"],
+   :image ["src" "mode" "width" "height"]})

--- a/src/composer/util.cljs
+++ b/src/composer/util.cljs
@@ -1,5 +1,7 @@
 
-(ns composer.util )
+(ns composer.util
+  (:require ["net" :as net])
+  (:require-macros [clojure.core.strint :refer [<<]]))
 
 (defn path-includes? [xs ys]
   (if (empty? ys)
@@ -18,5 +20,30 @@
   (->> templates vals (map (fn [template] [(:name template) (:markup template)])) (into {})))
 
 (defn path-with-children [path] (concat [:children] (interleave path (repeat :children))))
+
+(defn port-taken? [port next-fn]
+  (let [tester (.createServer net)]
+    (.. tester
+        (once
+         "error"
+         (fn [err]
+           (if (not= (.-code err) "EADDRINUSE") (next-fn err false) (next-fn nil true))))
+        (once
+         "listening"
+         (fn [] (.. tester (once "close" (fn [] (next-fn nil false))) (close))))
+        (listen port))))
+
+(defn pick-port! [port next-fn]
+  (port-taken?
+   port
+   (fn [err taken?]
+     (if (some? err)
+       (do (.error js/console err) (.exit js/process 1))
+       (if taken?
+         (do (println (<< "port ~{port} is in use.")) (pick-port! (inc port) next-fn))
+         (next-fn port))))))
+
+(defn specified-port! []
+  (let [raw js/process.env.port] (if (some? raw) (js/parseInt raw) nil)))
 
 (defn use-string-keys [x] (->> x (map (fn [[k v]] [(name k) v])) (into {})))

--- a/src/composer/util.cljs
+++ b/src/composer/util.cljs
@@ -1,7 +1,5 @@
 
-(ns composer.util
-  (:require ["net" :as net])
-  (:require-macros [clojure.core.strint :refer [<<]]))
+(ns composer.util (:require-macros [clojure.core.strint :refer [<<]]))
 
 (defn path-includes? [xs ys]
   (if (empty? ys)
@@ -20,28 +18,6 @@
   (->> templates vals (map (fn [template] [(:name template) (:markup template)])) (into {})))
 
 (defn path-with-children [path] (concat [:children] (interleave path (repeat :children))))
-
-(defn port-taken? [port next-fn]
-  (let [tester (.createServer net)]
-    (.. tester
-        (once
-         "error"
-         (fn [err]
-           (if (not= (.-code err) "EADDRINUSE") (next-fn err false) (next-fn nil true))))
-        (once
-         "listening"
-         (fn [] (.. tester (once "close" (fn [] (next-fn nil false))) (close))))
-        (listen port))))
-
-(defn pick-port! [port next-fn]
-  (port-taken?
-   port
-   (fn [err taken?]
-     (if (some? err)
-       (do (.error js/console err) (.exit js/process 1))
-       (if taken?
-         (do (println (<< "port ~{port} is in use.")) (pick-port! (inc port) next-fn))
-         (next-fn port))))))
 
 (defn specified-port! []
   (let [raw js/process.env.port] (if (some? raw) (js/parseInt raw) nil)))

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,20 +933,20 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shadow-cljs-jar@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.0.tgz#e25c4fa57c0b405096250884b164c112654a06a3"
-  integrity sha512-KReNVgFVM2ZPPGCP8rsCPqtlee/+SwXyoeEqbAXBO7jlpoNnNee2x4fiRg/Pr/vXGEkV/Ez5l4qdNSU1Na+1Jg==
+shadow-cljs-jar@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.1.tgz#a5f8ab7664b40e11345837e4c6bce8e0ac9b2cc3"
+  integrity sha512-IJSm4Gfu/wWDsOQ0wNrSxuaGdjzsd78us+3bop3cpWsoO2Igdu6VIBItYrZHRRBKl5LIZKXfnSh/2eWG3C1EFw==
 
-shadow-cljs@^2.8.31:
-  version "2.8.31"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.31.tgz#f3b7f4a1de49fa73355e85bdf7605307a9e0e6f0"
-  integrity sha512-3a25hF1CXFHIZQzo2rCIDWwMC2Hy9LGt/T75pW0vAw8JsahsnaL5O5Vg1+axJCM7deJoC0vwDByr/EsEcDkacQ==
+shadow-cljs@^2.8.32:
+  version "2.8.32"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.32.tgz#fdb0fcd45e09f82e6538f487dac59e849952932a"
+  integrity sha512-yE1ULqoPJ9OqmCX7J0cI2UcSw5k9CywPEvxKtVcflnpOOwXxDMyPIAckwhp+OXC4tL1BzSm8jMRHNNTkJsmkug==
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"
     readline-sync "^1.4.7"
-    shadow-cljs-jar "1.3.0"
+    shadow-cljs-jar "1.3.1"
     source-map-support "^0.4.15"
     which "^1.3.1"
     ws "^3.0.0"


### PR DESCRIPTION
* Changed layout for displaying more items.
* Added a "Font family" field, then we no longer need presets for fonts.

![image](https://user-images.githubusercontent.com/449224/56435042-978d8300-6309-11e9-9498-058ce090871b.png)

Updated:

* smartet code for picking a port.
