### PR TITLE
update code of backdrop-click action in popup; alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Introduction:
 [![Clojars Project](https://img.shields.io/clojars/v/respo/composer.svg)](https://clojars.org/respo/composer) ![respo/composer-app](https://img.shields.io/npm/v/@respo/composer-app.svg)
 
 ```edn
-[respo/composer "0.1.8"]
+[respo/composer "0.1.10"]
 ```
 
 ```bash
@@ -32,6 +32,8 @@ Elements tree editor:
 Templates overview:
 
 ![](http://wx4.sinaimg.cn/large/62752320gy1g0r8etufhwj20yq0u0n2o.jpg)
+
+Explainations for the properties are documented at https://github.com/Respo/composer.core .
 
 ### Workflow
 

--- a/calcit.edn
+++ b/calcit.edn
@@ -30661,17 +30661,50 @@
              }
             }
            }
-           "r" {
-            :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "CsyN6vgwv48e"
+           "p" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1557421979995, :id "c6SW4b2JG"
             :data {
-             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "action", :id "iltIHX-Lxp8u"}
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421990247, :text "backdrop-click-action", :id "c6SW4b2JGleaf"}
              "j" {
-              :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "B690qAvalMo7"
+              :type :expr, :by "B1y7Rc-Zz", :at 1557421990546, :id "2o1EDwpOW"
               :data {
-               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "get", :id "pzs2vpobk6ni"}
-               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "props", :id "eD6gm2xkVWaM"}
-               "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"action", :id "DHBLrp8_X-D_"}
-               "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "\"popup-close", :id "ReafY74msohn"}
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421991955, :text "get-in", :id "cUUkA3YKqS"}
+               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421993057, :text "markup", :id "Sj0rTEi25o"}
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1557421993367, :id "w-8396RcuB"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421993576, :text "[]", :id "6fQqyzcQy0"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421995209, :text ":event", :id "jlcMDRA2lG"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421998539, :text "\"backdrop-click", :id "_r_NybbFUH"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "u" {
+            :type :expr, :by "B1y7Rc-Zz", :at 1557422096608, :id "xAW6MOzvD8"
+            :data {
+             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text "param", :id "HRIujFHrLY"}
+             "j" {
+              :type :expr, :by "B1y7Rc-Zz", :at 1557422096608, :id "ySqfqnRVSd"
+              :data {
+               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text "read-token", :id "SLR0-XH-jL"}
+               "j" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1557422096608, :id "HeaDX5vafr"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text "get", :id "IclLQfFl6e"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text "props", :id "7SdZ_zn7aK"}
+                 "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text "\"param", :id "BoWeXTxb35"}
+                }
+               }
+               "r" {
+                :type :expr, :by "B1y7Rc-Zz", :at 1557422096608, :id "I_OwVlSbah"
+                :data {
+                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text ":data", :id "MoEuG4V0hP"}
+                 "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422096608, :text "context", :id "9BLpNVkTEP"}
+                }
+               }
               }
              }
             }
@@ -30794,30 +30827,94 @@
                    }
                   }
                  }
-                 "r" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "mLyHlWW1C73X"
+                 "v" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1557421780863, :id "6sxGSn11gI"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":on-click", :id "WC0fSt8rAkZQ"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421971047, :text ":on-click", :id "6sxGSn11gIleaf"}
                    "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "9kzii4Kerrr-"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1557421971443, :id "DYPfs2i1de"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "fn", :id "5yeLcAtGlJKH"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421971741, :text "fn", :id "nplUv7hcOm"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "HlFxGXPwFvR0"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1557421972672, :id "DAP2ULBAU"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "e", :id "Z4_C6StJoBdR"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "d!", :id "C3_86Ts71gaH"}
-                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "m!", :id "FfbpoUImN2xX"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421972878, :text "e", :id "qd5LpaK4mD"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421974656, :text "d!", :id "KR9E0iicZv"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1557421975452, :text "m!", :id "t2W9H_MFKO"}
                       }
                      }
                      "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "muoEXjP7t4qA"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1557422011959, :id "hv9vg-EggK"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "on-action", :id "f2al42TeMOfQ"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "d!", :id "OCEGi17lPeSo"}
-                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "action", :id "fKU119P3RRHi"}
-                       "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "props", :id "8TRSE2JZ5pwN"}
-                       "x" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "nil", :id "Kx1wyXJ19dp9"}
+                       "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422012571, :text "if", :id "F5pOJFseIN"}
+                       "L" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1557422013178, :id "SV8iJ0OUih"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422014345, :text "some?", :id "oGxvOpXo5T"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422014913, :text "backdrop-click-action", :id "U1R630Log"}
+                        }
+                       }
+                       "T" {
+                        :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "aFuhpdCdKF"
+                        :data {
+                         "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "on-action", :id "a2_puq_fv-"}
+                         "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "d!", :id "vs3kQ2x7eu"}
+                         "r" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "ciJotDqDwE"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "read-token", :id "T_jXCXcRkK"}
+                           "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422016988, :text "backdrop-click-action", :id "2bzs-gpjM8"}
+                           "r" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "RRKN0CIWVD"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text ":data", :id "K5NYDbbQyc"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "context", :id "eadgCySJE5"}
+                            }
+                           }
+                          }
+                         }
+                         "v" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "param", :id "TzaIpEQBdB"}
+                         "x" {
+                          :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "mJ26XDMxCt"
+                          :data {
+                           "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "{}", :id "7QGWqxjcY6"}
+                           "j" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "_5njoIPlUw"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text ":event", :id "C9aBFDhajQ"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "cwBuXOnwQh"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text ":event", :id "pBtg8gt861d"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "e", :id "ytBvabDrB-6"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "NYrgae-QSmI"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text ":props", :id "2z7Ne8_klZP"}
+                             "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "props", :id "phsH6pKYRJT"}
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "VsqVQIhcbHF"
+                            :data {
+                             "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text ":data", :id "mU6djQeFxEO"}
+                             "j" {
+                              :type :expr, :by "B1y7Rc-Zz", :at 1557422006682, :id "kLDJfr7oWcZ"
+                              :data {
+                               "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text ":data", :id "zEqxp99xcxn"}
+                               "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557422006682, :text "context", :id "6HcfocO-szT"}
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
                       }
                      }
                     }

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "composer",
-       :version "0.1.10",
+       :version "0.1.11-a1",
        :name "Respo composer renderer library"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/composer/core.cljs
+++ b/src/composer/core.cljs
@@ -383,7 +383,8 @@
 (defn render-popup [markup context on-action]
   (let [props (:props markup)
         value (read-token (get props "visible") (:data context))
-        action (get props "action" "popup-close")]
+        backdrop-click-action (get-in markup [:event "backdrop-click"])
+        param (read-token (get props "param") (:data context))]
     (if (:hide-popup? context)
       (comp-invalid "Popup is hidden in dev" props)
       (if value
@@ -397,7 +398,13 @@
                   :overflow :auto,
                   :padding 32,
                   :background-color (hsl 0 0 0 0.7)},
-          :on-click (fn [e d! m!] (on-action d! action props nil))}
+          :on-click (fn [e d! m!]
+            (if (some? backdrop-click-action)
+              (on-action
+               d!
+               (read-token backdrop-click-action (:data context))
+               param
+               {:event (:event e), :props props, :data (:data context)})))}
          (list->
           (merge
            {:on-click (fn [e d! m!] )}


### PR DESCRIPTION
Using `action` property directly was an old solution for events. In recent versions actions are replaced with event maps.
