### PR TITLE
Warn about color syntax

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -29613,7 +29613,7 @@
                     :type :expr, :by "B1y7Rc-Zz", :at 1560072748865, :id "z7NKUNb16o"
                     :data {
                      "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072756250, :text "re-matches", :id "jm6vCyf3S"}
-                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072836984, :text "#\"\\#[0-9a-f]{6}", :id "h7fVD6L3G3"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560074702725, :text "#\"^\\#[0-9a-f]{6}$", :id "h7fVD6L3G3"}
                      "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072776130, :text "v", :id "9VE242I3K"}
                     }
                    }

--- a/calcit.edn
+++ b/calcit.edn
@@ -29575,12 +29575,74 @@
                "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432976560, :text "[]", :id "wHUIkfqWV5leaf"}
                "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432977243, :text "k", :id "MzMF-AzF23"}
                "r" {
-                :type :expr, :by "B1y7Rc-Zz", :at 1555432978264, :id "fTFybRLeJ0"
+                :type :expr, :by "B1y7Rc-Zz", :at 1560072745307, :id "lQZqsmxrF_"
                 :data {
-                 "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432978264, :text "read-token", :id "cfjzSjHkGK"}
-                 "f" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432982720, :text "v", :id "IJShTOduqd"}
-                 "p" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432985139, :text "data", :id "fmQvhcHVX"}
-                 "u" {:type :leaf, :by "B1y7Rc-Zz", :at 1557683773876, :text "state", :id "IpZN-reD2w"}
+                 "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072747163, :text "cond", :id "M3IxPd2K7"}
+                 "L" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1560072748690, :id "A-pxijZhM"
+                  :data {
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072748865, :id "z7NKUNb16o"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072756250, :text "re-matches", :id "jm6vCyf3S"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560073020375, :text "#\"^\\#[0-9a-f]{3}$", :id "h7fVD6L3G3"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072776130, :text "v", :id "9VE242I3K"}
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072824141, :id "SEHiBmOMf"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072827112, :text "do", :id "xMAeKuMTTv"}
+                     "L" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072827936, :id "tUM240Z9Iz"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072917479, :text "js/console.warn", :id "jY0JItffz"}
+                       "f" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072957906, :text "\"Outdated color syntax", :id "aF8x8CfJ3"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072832974, :text "v", :id "hSnN5zaIop"}
+                      }
+                     }
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072823231, :text "v", :id "9ycd7bSyd"}
+                    }
+                   }
+                  }
+                 }
+                 "P" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1560072748690, :id "oBkSxYM4g"
+                  :data {
+                   "T" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072748865, :id "z7NKUNb16o"
+                    :data {
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072756250, :text "re-matches", :id "jm6vCyf3S"}
+                     "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072836984, :text "#\"\\#[0-9a-f]{6}", :id "h7fVD6L3G3"}
+                     "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072776130, :text "v", :id "9VE242I3K"}
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072824141, :id "SEHiBmOMf"
+                    :data {
+                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072827112, :text "do", :id "xMAeKuMTTv"}
+                     "L" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072967257, :id "qFB83PuFkE"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072967257, :text "js/console.warn", :id "yXAnCh1qCy"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072967257, :text "\"Outdated color syntax", :id "sH0Yo-RU5r"}
+                       "r" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072967257, :text "v", :id "CFZP_09LYO"}
+                      }
+                     }
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072823231, :text "v", :id "9ycd7bSyd"}
+                    }
+                   }
+                  }
+                 }
+                 "T" {
+                  :type :expr, :by "B1y7Rc-Zz", :at 1555432978264, :id "fTFybRLeJ0"
+                  :data {
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432978264, :text "read-token", :id "cfjzSjHkGK"}
+                   "f" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432982720, :text "v", :id "IJShTOduqd"}
+                   "p" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432985139, :text "data", :id "fmQvhcHVX"}
+                   "u" {:type :leaf, :by "B1y7Rc-Zz", :at 1557683773876, :text "state", :id "IpZN-reD2w"}
+                  }
+                 }
                 }
                }
               }
@@ -30202,65 +30264,65 @@
                 :data {
                  "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "ziDtgTuWkiVR"}
                  "j" {
-                  :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "N8FrX3wIMZlx"
+                  :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "srKFz0USVi"
                   :data {
-                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "merge", :id "ScHiPPQEpfwd"}
+                   "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "merge", :id "PY0B8VAxWB"}
                    "j" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "IP3rr_eektp9"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "LT3swSKjs7"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "get-layout", :id "GNEMJ4XI2mIz"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "get-layout", :id "cdQyJI_bg3"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "sfSZ3srB5OPy"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "oEFp-PT1DN"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":layout", :id "Poh6SQT5TCMa"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "C17Xizz4gfbs"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text ":layout", :id "JUiqnlLFwD"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "markup", :id "lU_OjwDudN"}
                       }
                      }
                     }
                    }
                    "r" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "1u0yPSsXnjm_"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "Ygkl00eXUK"
                     :data {
-                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "style-presets", :id "lUBCj_TFf54-"}
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "style-presets", :id "2hU7vUybQ0"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "xEEZV_Zm-DcZ"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "XwzN4H6OpG"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":presets", :id "GcmWVnNheWRT"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "eE7V5hH2M4MU"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text ":presets", :id "Y_5NEB5FtE"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "markup", :id "3Jn_Kr0dOn"}
                       }
                      }
                      "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1559396071242, :id "XXX5wWZ46y"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "GyyXGGySoa"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1559396077114, :text ":presets", :id "XXX5wWZ46yleaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1559396079387, :text "context", :id "i9lcDo_ok"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text ":presets", :id "EHlhwdx26oG"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "context", :id "fgd5JeWVMid"}
                       }
                      }
                     }
                    }
                    "v" {
-                    :type :expr, :by "B1y7Rc-Zz", :at 1555432916899, :id "k1CDaYHolw"
+                    :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "QlFCjtCDCZe"
                     :data {
-                     "D" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432921296, :text "read-styles", :id "gEj3qN3j8L"}
-                     "T" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1552499329915, :id "6CJEF5dEMStH"
-                      :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text ":style", :id "4ksHe2fZtcmJ"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1552499329915, :text "markup", :id "se4MzZHHEoxr"}
-                      }
-                     }
+                     "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "read-styles", :id "5tof_2gcisJ"}
                      "j" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1555432931208, :id "Sn2F7HlDU"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "6VnkNSa80jx"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432931754, :text ":data", :id "y4QIktj1b"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1555432932914, :text "context", :id "77NFrleynA"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text ":style", :id "VNVZeDf4q5l"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "markup", :id "3woxCKTfba_"}
                       }
                      }
                      "r" {
-                      :type :expr, :by "B1y7Rc-Zz", :at 1557684064900, :id "AidJ0-kdYN"
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "McwgTb5bhcQ"
                       :data {
-                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1557684064900, :text ":data", :id "hhM6XGMFaZ"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1557684064900, :text "states", :id "eHEgn05g8U"}
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text ":data", :id "fBw547Bp0zu"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "context", :id "aNiCDbDyLDe"}
+                      }
+                     }
+                     "v" {
+                      :type :expr, :by "B1y7Rc-Zz", :at 1560072731006, :id "ZgauRKjj5AM"
+                      :data {
+                       "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text ":data", :id "Uc62ZoujsOf"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560072731006, :text "states", :id "Ua2Nw4dvVY0"}
                       }
                      }
                     }

--- a/calcit.edn
+++ b/calcit.edn
@@ -7664,7 +7664,7 @@
                       :type :expr, :by "B1y7Rc-Zz", :at 1548770469475, :id "ldVDll0Ckn"
                       :data {
                        "T" {:type :leaf, :by "B1y7Rc-Zz", :at 1548770470682, :text ":padding", :id "ldVDll0Cknleaf"}
-                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1551552351257, :text "\"0 8px", :id "-v_ouatJ9x"}
+                       "j" {:type :leaf, :by "B1y7Rc-Zz", :at 1560074297307, :text "\"0 8px 120px 8px", :id "-v_ouatJ9x"}
                       }
                      }
                     }

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "composer",
-       :version "0.1.17-a1",
+       :version "0.1.17-a2",
        :name "Respo composer renderer library"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "composer",
-       :version "0.1.17-a2",
+       :version "0.1.17-a3",
        :name "Respo composer renderer library"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/composer/comp/editor.cljs
+++ b/src/composer/comp/editor.cljs
@@ -247,7 +247,7 @@
    (=< nil 4)
    (cursor-> :operations comp-operations states template (or focused-path []))
    (div
-    {:style (merge ui/flex {:overflow :auto, :padding "0 8px"})}
+    {:style (merge ui/flex {:overflow :auto, :padding "0 8px 120px 8px"})}
     (comp-markup (:markup template) [] focused-path active-paths)
     (when config/dev? (comp-inspect "Markup" (:markup template) {:bottom 0}))))
   (div {:style {:width 1, :background-color "#eee"}})

--- a/src/composer/core.cljs
+++ b/src/composer/core.cljs
@@ -115,7 +115,18 @@
     (->> attrs (map (fn [[k v]] [(keyword k) (read-token v data state)])) (into {}))))
 
 (defn read-styles [style data state]
-  (->> style (map (fn [[k v]] [k (read-token v data state)])) (into {})))
+  (->> style
+       (map
+        (fn [[k v]]
+          [k
+           (cond
+             (re-matches #"^\#[0-9a-f]{3}$" v)
+               (do (js/console.warn "Outdated color syntax" v) v)
+             (re-matches #"\#[0-9a-f]{6}" v)
+               (do (js/console.warn "Outdated color syntax" v) v)
+             read-token v
+             data state)]))
+       (into {})))
 
 (defn style-presets [preset-ids presets]
   (->> preset-ids

--- a/src/composer/core.cljs
+++ b/src/composer/core.cljs
@@ -122,7 +122,7 @@
            (cond
              (re-matches #"^\#[0-9a-f]{3}$" v)
                (do (js/console.warn "Outdated color syntax" v) v)
-             (re-matches #"\#[0-9a-f]{6}" v)
+             (re-matches #"^\#[0-9a-f]{6}$" v)
                (do (js/console.warn "Outdated color syntax" v) v)
              read-token v
              data state)]))


### PR DESCRIPTION
Reading states requires the syntax of `#:a`. Styles allows syntax like `#aaa`. There's some conflicts that breaks real apps. So I added warning to indicated the awkward.
